### PR TITLE
[MCOMPILER-341] Compile module descriptors with TestCompilerMojo

### DIFF
--- a/src/it/jpms_compile-main-empty-test-bar/invoker.properties
+++ b/src/it/jpms_compile-main-empty-test-bar/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.java.version = 9+

--- a/src/it/jpms_compile-main-empty-test-bar/pom.xml
+++ b/src/it/jpms_compile-main-empty-test-bar/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.compiler.it</groupId>
+    <artifactId>compile-main-empty-test-bar</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>@project.version@</version>
+                    <configuration>
+                        <release>9</release>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/src/it/jpms_compile-main-empty-test-bar/src/test/java/bar/BarTests.java
+++ b/src/it/jpms_compile-main-empty-test-bar/src/test/java/bar/BarTests.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package bar;
+
+import javax.script.*;
+import org.junit.jupiter.api.*;
+
+class BarTests
+{
+    @Test
+    void scripting() throws ScriptException
+    {
+        ScriptEngineManager factory = new ScriptEngineManager();
+        ScriptEngine engine = factory.getEngineByName( "JavaScript" );
+        Assertions.assertDoesNotThrow​( () -> engine.eval( "print('Hello, World')" ), "Script evaluation failed!" );
+    }
+}

--- a/src/it/jpms_compile-main-empty-test-bar/src/test/java/module-info.java
+++ b/src/it/jpms_compile-main-empty-test-bar/src/test/java/module-info.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+open module bar
+{
+    requires java.scripting;
+    requires org.junit.jupiter.api;
+}

--- a/src/it/jpms_compile-main-empty-test-bar/verify.groovy
+++ b/src/it/jpms_compile-main-empty-test-bar/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File( basedir, "target/test-classes/module-info.class" ).exists()
+assert new File( basedir, "target/test-classes/bar/BarTests.class" ).exists()

--- a/src/it/jpms_compile-main-foo-test-bar/invoker.properties
+++ b/src/it/jpms_compile-main-foo-test-bar/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.java.version = 9+

--- a/src/it/jpms_compile-main-foo-test-bar/pom.xml
+++ b/src/it/jpms_compile-main-foo-test-bar/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.compiler.it</groupId>
+    <artifactId>compile-test-modules</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>@project.version@</version>
+                    <configuration>
+                        <release>9</release>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/src/it/jpms_compile-main-foo-test-bar/src/main/java/foo/Foo.java
+++ b/src/it/jpms_compile-main-foo-test-bar/src/main/java/foo/Foo.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package foo;
+
+import org.apache.commons.lang3.*;
+
+public class Foo
+{
+    public Foo()
+    {
+        System.out.println( StringUtils.swapCase( "fOO" ) + " created!" );
+    }
+}

--- a/src/it/jpms_compile-main-foo-test-bar/src/main/java/module-info.java
+++ b/src/it/jpms_compile-main-foo-test-bar/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module foo
+{
+    requires org.apache.commons.lang3;
+    exports foo;
+}

--- a/src/it/jpms_compile-main-foo-test-bar/src/test/java/bar/BarTests.java
+++ b/src/it/jpms_compile-main-foo-test-bar/src/test/java/bar/BarTests.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package bar;
+
+import foo.*;
+import org.junit.jupiter.api.*;
+
+class BarTests
+{
+    @Test
+    void constructor()
+    {
+        Assertions.assertNotNull( new Foo() );
+    }
+
+    @Test
+    void moduleNameIsFoo()
+    {
+        Assertions.assertTrue( Foo.class.getModule().isNamed(), "Foo resides in a named module" );
+        Assertions.assertEquals( "foo", Foo.class.getModule().getName() );
+    }
+}

--- a/src/it/jpms_compile-main-foo-test-bar/src/test/java/module-info.java
+++ b/src/it/jpms_compile-main-foo-test-bar/src/test/java/module-info.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+open module bar
+{
+    requires foo;
+    requires java.scripting;
+    requires org.junit.jupiter.api;
+}

--- a/src/it/jpms_compile-main-foo-test-bar/verify.groovy
+++ b/src/it/jpms_compile-main-foo-test-bar/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File( basedir, "target/classes/module-info.class" ).exists()
+assert new File( basedir, "target/classes/foo/Foo.class" ).exists()
+
+assert new File( basedir, "target/test-classes/module-info.class" ).exists()
+assert new File( basedir, "target/test-classes/bar/BarTests.class" ).exists()

--- a/src/it/jpms_compile-main-foo-test-foo/invoker.properties
+++ b/src/it/jpms_compile-main-foo-test-foo/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.java.version = 9+

--- a/src/it/jpms_compile-main-foo-test-foo/pom.xml
+++ b/src/it/jpms_compile-main-foo-test-foo/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.compiler.it</groupId>
+    <artifactId>compile-test-modules</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>@project.version@</version>
+                    <configuration>
+                        <release>9</release>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/src/it/jpms_compile-main-foo-test-foo/src/main/java/foo/Foo.java
+++ b/src/it/jpms_compile-main-foo-test-foo/src/main/java/foo/Foo.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package foo;
+
+import org.apache.commons.lang3.*;
+
+class Foo
+{
+    Foo()
+    {
+        System.out.println( StringUtils.swapCase( "fOO" ) + " created!" );
+    }
+}

--- a/src/it/jpms_compile-main-foo-test-foo/src/main/java/module-info.java
+++ b/src/it/jpms_compile-main-foo-test-foo/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module foo
+{
+    requires org.apache.commons.lang3;
+}

--- a/src/it/jpms_compile-main-foo-test-foo/src/test/java/foo/FooTests.java
+++ b/src/it/jpms_compile-main-foo-test-foo/src/test/java/foo/FooTests.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package foo;
+
+import org.junit.jupiter.api.*;
+
+class FooTests
+{
+    @Test
+    void constructor()
+    {
+        Assertions.assertNotNull( new Foo() );
+    }
+
+    @Test
+    void moduleNameIsFoo()
+    {
+        Assertions.assertTrue( Foo.class.getModule().isNamed(), "Foo resides in a named module" );
+        Assertions.assertEquals( "foo", Foo.class.getModule().getName() );
+    }
+}

--- a/src/it/jpms_compile-main-foo-test-foo/src/test/java/module-info.java
+++ b/src/it/jpms_compile-main-foo-test-foo/src/test/java/module-info.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+open module foo
+{
+    // main
+    requires org.apache.commons.lang3;
+
+    // test
+    requires java.scripting;
+    requires org.junit.jupiter.api;
+}

--- a/src/it/jpms_compile-main-foo-test-foo/verify.groovy
+++ b/src/it/jpms_compile-main-foo-test-foo/verify.groovy
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def jpmsArgs = new File( basedir, 'target/test-classes/META-INF/jpms.args' )
+def lines = jpmsArgs.readLines()
+assert lines[0] == "--patch-module"
+assert lines[1].startsWith( "foo=" )
+assert lines[1].contains( java.nio.file.Paths.get ("src", "main", "java").toString() )
+
+assert new File( basedir, "target/classes/module-info.class" ).exists()
+assert new File( basedir, "target/classes/foo/Foo.class" ).exists()
+
+assert new File( basedir, "target/test-classes/module-info.class" ).exists()
+assert new File( basedir, "target/test-classes/foo/Foo.class" ).exists()
+assert new File( basedir, "target/test-classes/foo/FooTests.class" ).exists()

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -1005,7 +1005,14 @@ public abstract class AbstractCompilerMojo
                         
                         if ( descriptor == null )
                         {
-                            getLog().warn( "Can't locate " + file );
+                            if ( Files.isDirectory( filePath ) )
+                            {
+                                patchModules.add( file );
+                            }
+                            else
+                            {
+                                getLog().warn( "Can't locate " + file );
+                            }
                         }
                         else if ( !values[0].equals( descriptor.name() ) )
                         {

--- a/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
@@ -21,6 +21,8 @@ package org.apache.maven.plugin.compiler;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -207,22 +209,84 @@ public class TestCompilerMojo
     protected void preparePaths( Set<File> sourceFiles )
     {
         File mainOutputDirectory = new File( getProject().getBuild().getOutputDirectory() );
-        
-        File mainModuleDescriptor = new File( mainOutputDirectory, "module-info.class" );
 
-        boolean hasTestModuleDescriptor = false;
-        
-        // Go through the source files to respect includes/excludes 
+        File mainModuleDescriptorClassFile = new File( mainOutputDirectory, "module-info.class" );
+        JavaModuleDescriptor mainModuleDescriptor = null;
+
+        File testModuleDescriptorJavaFile = new File( "module-info.java" );
+        JavaModuleDescriptor testModuleDescriptor = null;
+
+        // Go through the source files to respect includes/excludes
         for ( File sourceFile : sourceFiles )
         {
             // @todo verify if it is the root of a sourcedirectory?
             if ( "module-info.java".equals( sourceFile.getName() ) ) 
             {
-                hasTestModuleDescriptor = true;
+                testModuleDescriptorJavaFile = sourceFile;
                 break;
             }
         }
-        
+
+        // Get additional information from the main module descriptor, if available
+        if ( mainModuleDescriptorClassFile.exists() )
+        {
+            ResolvePathsResult<String> result;
+
+            try
+            {
+                ResolvePathsRequest<String> request =
+                        ResolvePathsRequest.withStrings( testPath )
+                                .setMainModuleDescriptor( mainModuleDescriptorClassFile.getAbsolutePath() );
+
+                Toolchain toolchain = getToolchain();
+                if ( toolchain != null && toolchain instanceof DefaultJavaToolChain )
+                {
+                    request.setJdkHome( ( (DefaultJavaToolChain) toolchain ).getJavaHome() );
+                }
+
+                result = locationManager.resolvePaths( request );
+            }
+            catch ( IOException e )
+            {
+                throw new RuntimeException( e );
+            }
+
+            mainModuleDescriptor = result.getMainModuleDescriptor();
+
+            pathElements = new LinkedHashMap<String, JavaModuleDescriptor>( result.getPathElements().size() );
+            pathElements.putAll( result.getPathElements() );
+
+            modulepathElements = result.getModulepathElements().keySet();
+            classpathElements = result.getClasspathElements();
+        }
+
+        // Get additional information from the test module descriptor, if available
+        if ( testModuleDescriptorJavaFile.exists() )
+        {
+            ResolvePathsResult<String> result;
+
+            try
+            {
+                ResolvePathsRequest<String> request =
+                        ResolvePathsRequest.withStrings( testPath )
+                                .setMainModuleDescriptor( testModuleDescriptorJavaFile.getAbsolutePath() );
+
+                Toolchain toolchain = getToolchain();
+                if ( toolchain != null && toolchain instanceof DefaultJavaToolChain )
+                {
+                    request.setJdkHome( ( (DefaultJavaToolChain) toolchain ).getJavaHome() );
+                }
+
+                result = locationManager.resolvePaths( request );
+            }
+            catch ( IOException e )
+            {
+                throw new RuntimeException( e );
+            }
+
+            testModuleDescriptor = result.getMainModuleDescriptor();
+        }
+
         if ( release != null )
         {
             if ( Integer.valueOf( release ) < 9 )
@@ -241,17 +305,54 @@ public class TestCompilerMojo
             return;
         }
             
-        if ( hasTestModuleDescriptor )
+        if ( testModuleDescriptor != null )
         {
             modulepathElements = testPath;
             classpathElements = Collections.emptyList();
 
-            if ( mainModuleDescriptor.exists() )
+            if ( mainModuleDescriptor != null )
             {
-                // maybe some extra analysis required
+                if ( getLog().isDebugEnabled() )
+                {
+                    getLog().debug( "Main and test module descriptors exist:" );
+                    getLog().debug( "  main module = " + mainModuleDescriptor.name() );
+                    getLog().debug( "  test module = " + testModuleDescriptor.name() );
+                }
+
+                if ( testModuleDescriptor.name().equals( mainModuleDescriptor.name() ) )
+                {
+                    if ( compilerArgs == null )
+                    {
+                        compilerArgs = new ArrayList<String>();
+                    }
+                    compilerArgs.add( "--patch-module" );
+
+                    StringBuilder patchModuleValue = new StringBuilder();
+                    patchModuleValue.append( testModuleDescriptor.name() );
+                    patchModuleValue.append( '=' );
+
+                    for ( String root : getProject().getCompileSourceRoots() )
+                    {
+                        if ( Files.exists( Paths.get( root ) ) )
+                        {
+                            patchModuleValue.append( root ).append( PS );
+                        }
+                    }
+
+                    compilerArgs.add( patchModuleValue.toString() );
+                }
+                else
+                {
+                    getLog().debug( "Black-box testing - all is ready to compile" );
+                }
             }
             else
             {
+                // No main binaries available? Means we're a test-only project.
+                if ( !mainOutputDirectory.exists() )
+                {
+                    return;
+                }
                 // very odd
                 // Means that main sources must be compiled with -modulesource and -Xmodule:<moduleName>
                 // However, this has a huge impact since you can't simply use it as a classpathEntry 
@@ -262,44 +363,15 @@ public class TestCompilerMojo
         }
         else
         {
-            if ( mainModuleDescriptor.exists() )
+            if ( mainModuleDescriptor != null )
             {
-                ResolvePathsResult<String> result;
-                
-                try
-                {
-                    ResolvePathsRequest<String> request =
-                        ResolvePathsRequest.withStrings( testPath )
-                                           .setMainModuleDescriptor( mainModuleDescriptor.getAbsolutePath() );
-                    
-                    Toolchain toolchain = getToolchain();
-                    if ( toolchain != null && toolchain instanceof DefaultJavaToolChain )
-                    {
-                        request.setJdkHome( ( (DefaultJavaToolChain) toolchain ).getJavaHome() );
-                    }
-                    
-                    result = locationManager.resolvePaths( request );
-                }
-                catch ( IOException e )
-                {
-                    throw new RuntimeException( e );
-                }
-                
-                JavaModuleDescriptor moduleDescriptor = result.getMainModuleDescriptor();
-                
-                pathElements = new LinkedHashMap<String, JavaModuleDescriptor>( result.getPathElements().size() );
-                pathElements.putAll( result.getPathElements() );
-                                
-                modulepathElements = result.getModulepathElements().keySet();
-                classpathElements = result.getClasspathElements();
-                
                 if ( compilerArgs == null )
                 {
                     compilerArgs = new ArrayList<String>();
                 }
                 compilerArgs.add( "--patch-module" );
                 
-                StringBuilder patchModuleValue = new StringBuilder( moduleDescriptor.name() )
+                StringBuilder patchModuleValue = new StringBuilder( mainModuleDescriptor.name() )
                                 .append( '=' )
                                 .append( mainOutputDirectory )
                                 .append( PS );
@@ -311,7 +383,7 @@ public class TestCompilerMojo
                 compilerArgs.add( patchModuleValue.toString() );
                 
                 compilerArgs.add( "--add-reads" );
-                compilerArgs.add( moduleDescriptor.name() + "=ALL-UNNAMED" );
+                compilerArgs.add( mainModuleDescriptor.name() + "=ALL-UNNAMED" );
             }
             else
             {

--- a/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTestCase.java
+++ b/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTestCase.java
@@ -419,6 +419,8 @@ public class CompilerMojoTestCase
         setVariableValueToObject( mojo, "compileSourceRoots", Collections.singletonList( testSourceRoot ) );
 
         MavenProject project = getMockMavenProject();
+        project.setFile( testPom );
+        project.addCompileSourceRoot("/src/main/java" );
         project.setArtifacts( Collections.singleton( junitArtifact )  );
         project.getBuild().setOutputDirectory( new File( buildDir, "classes" ).getAbsolutePath() );
         setVariableValueToObject( mojo, "project", project );


### PR DESCRIPTION
Prior to this commit module descriptors `module-info.java` were not compiled by the TestCompilerMojo. This commit introduces support for test sources organized with module descriptors.

See motivation: https://twitter.com/rfscholte/status/927132319374331904

Supersedes: https://github.com/apache/maven-plugins/pull/139