### PR TITLE
[MCOMPILER-306] Fix `compilerArgs` example usage

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -336,7 +336,8 @@ public abstract class AbstractCompilerMojo
      * Example:
      * <pre>
      * &lt;compilerArgs&gt;
-     *   &lt;arg&gt;-Xmaxerrs=1000&lt;/arg&gt;
+     *   &lt;arg&gt;-Xmaxerrs&lt;/arg&gt;
+     *   &lt;arg&gt;1000&lt;/arg&gt;
      *   &lt;arg&gt;-Xlint&lt;/arg&gt;
      *   &lt;arg&gt;-J-Duser.language=en_us&lt;/arg&gt;
      * &lt;/compilerArgs&gt;


### PR DESCRIPTION
This is a resubmission of PR apache/maven-plugins#126.

I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).