### PR TITLE
Use junit-platform-maven-plugin w/o isolating test runtime jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@ under the License.
     <groovyEclipseCompilerVersion>2.7.0-01</groovyEclipseCompilerVersion>
     <groovy-eclipse-batch>2.0.4-04</groovy-eclipse-batch>
     <openJpaVersion>2.4.2</openJpaVersion>
+    <junitPlatformPluginVersion>1.0.0-M5</junitPlatformPluginVersion>
     <javaVersion>7</javaVersion>
     <maven.it.failure.ignore>false</maven.it.failure.ignore>
   </properties>
@@ -182,7 +183,7 @@ under the License.
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
+      <version>2.23.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -352,6 +353,68 @@ under the License.
             </plugin>
           </plugins>
         </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>java8+</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <!--
+            A plugin that launches the JUnit Platform using the Vintage
+            engine to start our junit suite "AllTests".
+            -->
+            <groupId>de.sormuras.junit</groupId>
+            <artifactId>junit-platform-maven-plugin</artifactId>
+            <version>${junitPlatformPluginVersion}</version>
+
+            <!--
+            Add this plugin's "launch" goal to test phase executions and
+            clear all executions of Surefire...
+            -->
+            <extensions>true</extensions>
+            <!--
+            ...or add this plugin manually without touching Surefire.
+            -->
+            <!--<executions>-->
+              <!--<execution>-->
+                <!--<id>launch-junit-platform</id>-->
+                <!--<phase>test</phase>-->
+                <!--<goals>-->
+                  <!--<goal>launch</goal>-->
+                <!--</goals>-->
+              <!--</execution>-->
+            <!--</executions>-->
+
+              <configuration>
+                  <!--
+                  Execution mode: One of DIRECT (default) | JAVA
+                  -->
+                  <!--<executor>DIRECT</executor>-->
+
+                  <!--
+                  Isolation level: One of ABSOLUTE | ALMOST | MERGED (default) | NONE
+                  -->
+                  <!--<isolation>MERGED</isolation>-->
+
+                  <!--
+                  Dry-run: Discover tests only - i.e. write test-plan and exit.
+                  -->
+                  <dryRun>false</dryRun>
+
+                  <!--
+                  JUnit Platform doesn't include ".*TestCase" per default. We
+                  add it here to the standard pattern.
+                  -->
+                  <classNamePatterns>
+                      <pattern>^(Test.*|.+[.$]Test.*|.*Tests|.*TestCase?)$</pattern>
+                  </classNamePatterns>
+              </configuration>
+          </plugin>
+        </plugins>
       </build>
     </profile>
   </profiles>


### PR DESCRIPTION
# Note

_This is just a "proof-of-concept" and always "work-in-progress" PR to show-case what the junit-platform-maven-plugin looks like. It's also much easier to attach notes to source code here than in JIRA._

## Overview

Launching the JUnit Platform "in-process" *without* isolating test and main path sets.

```xml
      <plugin>
        <groupId>de.sormuras.junit</groupId>
        <artifactId>junit-platform-maven-plugin</artifactId>
        <version>1.0.0-Mx</version>
        <extensions>true</extensions>
        <configuration>
          <executor>DIRECT</executor>
          <isolation>MERGED</isolation>
        </configuration>
      </plugin>
```

### Summary
```
Test run finished after 2820 ms
[         2 containers found      ]
[         0 containers skipped    ]
[         2 containers started    ]
[         0 containers aborted    ]
[         2 containers successful ]
[         0 containers failed     ]
[        12 tests found           ]
[         0 tests skipped         ]
[        12 tests started         ]
[         0 tests aborted         ]
[        12 tests successful      ]
[         0 tests failed          ]
```

### Using `<isolation>MERGED</isolation>`

...the jars are isolated as follows:
```
merged(test+main)
  test-classes                                                                
  maven-aether-provider-3.0.jar                  
  plexus-compiler-javac-2.8.4.jar                
  maven-plugin-testing-harness-2.1.jar           
  plexus-archiver-2.2.jar                        
  plexus-container-default-1.0-alpha-9-stable-1.jar
  classworlds-1.1-alpha-2.jar                    
  plexus-io-2.0.4.jar                            
  maven-compat-3.0.jar                           
  wagon-provider-api-1.0-beta-6.jar              
  mockito-core-1.9.5.jar                         
  hamcrest-core-1.1.jar                          
  objenesis-1.0.jar                              
  junit-4.12.jar                                 
  classes           
  maven-plugin-annotations-3.5.2.jar             
  maven-plugin-api-3.0.jar                       
  maven-model-3.0.jar                            
  sisu-inject-plexus-1.4.2.jar                   
  sisu-inject-bean-1.4.2.jar                     
  sisu-guice-2.1.7-noaop.jar                     
  maven-artifact-3.0.jar                         
  plexus-utils-2.0.4.jar                         
  maven-core-3.0.jar                             
  maven-settings-3.0.jar                         
  maven-settings-builder-3.0.jar                 
  maven-repository-metadata-3.0.jar              
  maven-model-builder-3.0.jar                    
  aether-impl-1.7.jar                            
  aether-spi-1.7.jar                             
  aether-api-1.7.jar                             
  aether-util-1.7.jar                            
  plexus-interpolation-1.14.jar                  
  plexus-classworlds-2.2.3.jar                   
  plexus-component-annotations-1.7.1.jar         
  plexus-sec-dispatcher-1.3.jar                  
  plexus-cipher-1.4.jar                          
  maven-shared-utils-3.2.1.jar                   
  commons-io-2.5.jar                             
  maven-shared-incremental-1.1.jar               
  plexus-java-0.9.10.jar                         
  asm-6.2.jar                                    
  qdox-2.0-M9.jar                                
  plexus-compiler-api-2.8.4.jar                  
  plexus-compiler-manager-2.8.4.jar              
launcher
  junit-platform-launcher-1.3.2.jar              
  apiguardian-api-1.0.0.jar                      
  junit-platform-engine-1.3.2.jar                
  junit-platform-commons-1.3.2.jar               
  opentest4j-1.1.1.jar                           
  junit-vintage-engine-5.3.2.jar                 
  hamcrest-core-1.3.jar                          
isolator
  junit-platform-isolator-worker-1.0.0-M5.jar    
  junit-platform-isolator-1.0.0-M5.jar           
```

### Using `<isolation>ABSOLUTE|ALMOST</isolation>`

...and **no tests** are found by the Vintage engine. I guess, main classes need to access test classes, somehow. Injection?