### PR TITLE
MCOMPILER-349 cleanups

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -472,7 +472,7 @@ public abstract class AbstractCompilerMojo
 
     /**
      * file extensions to check timestamp for incremental build
-     * <b>default contains only <code>.class</code></b>
+     * <b>default contains only <code>class</code></b>
      *
      * @since 3.1
      */

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -1566,8 +1567,7 @@ public abstract class AbstractCompilerMojo
 
         if ( fileExtensions == null || fileExtensions.isEmpty() )
         {
-            fileExtensions = new ArrayList<>();
-            fileExtensions.add( "class" );
+            fileExtensions = Collections.singletonList( "class" );
         }
 
         Date buildStartTime = getBuildStartTime();


### PR DESCRIPTION
This is maybe a bit rude, piggy-backing on an old Jira ticket but it didn't seem to quite warrant a new one.

Correct a tiny error in the documentation and simplify the code around handling the default set of file extensions to monitor for timestamp changes during incremental compilation.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)