### PR TITLE
(doc) Simplify CompilationFailureException

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/CompilationFailureException.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilationFailureException.java
@@ -73,17 +73,11 @@ public class CompilationFailureException
      */
     public static String shortMessage( List<CompilerMessage> messages )
     {
-        StringBuilder sb = new StringBuilder();
-
-        sb.append( "Compilation failure" );
+        StringBuilder sb = new StringBuilder( "Compilation failure" );
 
         if ( messages.size() == 1 )
         {
-            sb.append( LS );
-
-            CompilerMessage compilerError = messages.get( 0 );
-
-            sb.append( compilerError ).append( LS );
+            sb.append( LS ).append( messages.get( 0 ) ).append( LS );
         }
 
         return sb.toString();

--- a/src/main/java/org/apache/maven/plugin/compiler/CompilationFailureException.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilationFailureException.java
@@ -34,11 +34,24 @@ public class CompilationFailureException
 {
     private static final String LS = System.getProperty( "line.separator" );
 
+    /**
+     * Wrap error messages from the compiler
+     *
+     * @param messages the messages
+     * @since 2.0
+     */
     public CompilationFailureException( List<CompilerMessage> messages )
     {
         super( null, shortMessage( messages ), longMessage( messages ) );
     }
 
+    /**
+     * Long message will have all messages, one per line
+     *
+     * @param messages the messages
+     * @return the long error message
+     * @since 2.0
+     */
     public static String longMessage( List<CompilerMessage> messages )
     {
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/apache/maven/plugin/compiler/CompilationFailureException.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilationFailureException.java
@@ -37,7 +37,7 @@ public class CompilationFailureException
     /**
      * Wrap error messages from the compiler
      *
-     * @param messages the messages
+     * @param messages the messages, not null
      * @since 2.0
      */
     public CompilationFailureException( List<CompilerMessage> messages )
@@ -48,7 +48,7 @@ public class CompilationFailureException
     /**
      * Long message will have all messages, one per line
      *
-     * @param messages the messages
+     * @param messages the messages, not null
      * @return the long error message
      * @since 2.0
      */
@@ -56,20 +56,18 @@ public class CompilationFailureException
     {
         StringBuilder sb = new StringBuilder();
 
-        if ( messages != null )
+        for ( CompilerMessage compilerError : messages )
         {
-            for ( CompilerMessage compilerError : messages )
-            {
-                sb.append( compilerError ).append( LS );
-            }
+            sb.append( compilerError ).append( LS );
         }
+
         return sb.toString();
     }
 
     /**
      * Short message will have the error message if there's only one, useful for errors forking the compiler
      *
-     * @param messages the messages
+     * @param messages the messages, not null
      * @return the short error message
      * @since 2.0.2
      */


### PR DESCRIPTION
This class can be a little bit more concise.

The nullity check in `longMessage()` is made redundant by the lack of an equivalent check in `shortMessage`. `CompilationFailureException` is thrown in two places in `AbstractCompilerMojo` and both of those are guaranteed to pass a non-null object.

Whilst we're in here, remove a redundant local variable in `shortMessage()` and merge the `StringBuilder` calls onto a single line.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

