### PR TITLE
Cleanup debug log handling

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -963,7 +963,7 @@ public abstract class AbstractCompilerMojo
                 }
 
                 String[] cl = compiler.createCommandLine( compilerConfiguration );
-                if ( getLog().isDebugEnabled() && cl != null && cl.length > 0 )
+                if ( cl != null && cl.length > 0 )
                 {
                     StringBuilder sb = new StringBuilder();
                     sb.append( cl[0] );

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -859,11 +859,14 @@ public abstract class AbstractCompilerMojo
             {
                 // MCOMPILER-366: if sources contain the module-descriptor it must be used to define the modulepath
                 sources = getCompileSources( compiler, compilerConfiguration );
-                
-                getLog().debug( "#sources: " + sources.size() );
-                for ( File file : sources )
+
+                if ( getLog().isDebugEnabled() )
                 {
-                    getLog().debug( file.getPath() );
+                    getLog().debug( "#sources: " + sources.size() );
+                    for ( File file : sources )
+                    {
+                        getLog().debug( file.getPath() );
+                    }
                 }
 
                 preparePaths( sources );


### PR DESCRIPTION
Make better use of `isDebugEnabled()`. See individual commits for details.

The diff looks better if you ignore whitespace changes.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)