### PR TITLE
[MCOMPILER-389] Upgrade plexus-compiler-javac to 2.8.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@ under the License.
       ! The following property is used in the integration tests MCOMPILER-157
     -->
     <mavenPluginPluginVersion>3.5</mavenPluginPluginVersion>
-    <plexusCompilerVersion>2.8.4</plexusCompilerVersion>
+    <plexusCompilerVersion>2.8.5</plexusCompilerVersion>
     <groovyVersion>1.8.0</groovyVersion>
     <groovyEclipseCompilerVersion>2.7.0-01</groovyEclipseCompilerVersion>
     <groovy-eclipse-batch>2.0.4-04</groovy-eclipse-batch>


### PR DESCRIPTION
This claims to fix ECJ's error reporting

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)