### PR TITLE
[MCOMPILER-398] - Simplify includes/excludes scanning code

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
@@ -357,22 +357,17 @@ public class CompilerMojo
     
     protected SourceInclusionScanner getSourceInclusionScanner( int staleMillis )
     {
-        SourceInclusionScanner scanner;
-
         if ( includes.isEmpty() && excludes.isEmpty() )
         {
-            scanner = new StaleSourceScanner( staleMillis );
-        }
-        else
-        {
-            if ( includes.isEmpty() )
-            {
-                includes.add( "**/*.java" );
-            }
-            scanner = new StaleSourceScanner( staleMillis, includes, excludes );
+            return new StaleSourceScanner( staleMillis );
         }
 
-        return scanner;
+        if ( includes.isEmpty() )
+        {
+            includes.add( "**/*.java" );
+        }
+
+        return new StaleSourceScanner( staleMillis, includes, excludes );
     }
 
     protected SourceInclusionScanner getSourceInclusionScanner( String inputFileEnding )

--- a/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
@@ -377,26 +377,15 @@ public class CompilerMojo
 
     protected SourceInclusionScanner getSourceInclusionScanner( String inputFileEnding )
     {
-        SourceInclusionScanner scanner;
-
         // it's not defined if we get the ending with or without the dot '.'
         String defaultIncludePattern = "**/*" + ( inputFileEnding.startsWith( "." ) ? "" : "." ) + inputFileEnding;
 
-        if ( includes.isEmpty() && excludes.isEmpty() )
+        if ( includes.isEmpty() )
         {
-            includes = Collections.singleton( defaultIncludePattern );
-            scanner = new SimpleSourceInclusionScanner( includes, Collections.<String>emptySet() );
-        }
-        else
-        {
-            if ( includes.isEmpty() )
-            {
-                includes.add( defaultIncludePattern );
-            }
-            scanner = new SimpleSourceInclusionScanner( includes, excludes );
+            includes.add( defaultIncludePattern );
         }
 
-        return scanner;
+        return new SimpleSourceInclusionScanner( includes, excludes );
     }
 
     protected String getSource()


### PR DESCRIPTION
Attempt to make the code handling inclusion/exclusion of files simpler to follow.

Note: I couldn't get the tests passing, even on master, so I haven't really tested this change.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
