### PR TITLE
[MCOMPILER-399] Upgrade mockito from 1.9.5 to 2.28.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@ under the License.
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
+      <version>2.28.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTestCase.java
+++ b/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTestCase.java
@@ -19,7 +19,7 @@ package org.apache.maven.plugin.compiler;
  * under the License.
  */
 
-import static org.mockito.Matchers.startsWith;
+import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
This builds alright for me (admittedly, on Java 11)

Mockito 2.x still supports Java 6, however, so I think this is OK?

 - [x ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)