### PR TITLE
[MCOMPILER-417] - Document compileSourceRoots parameters

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
@@ -65,7 +65,7 @@ public class CompilerMojo
     /**
      * The source directories containing the sources to be compiled.
      */
-    @Parameter( defaultValue = "${project.compileSourceRoots}", readonly = true, required = true )
+    @Parameter( defaultValue = "${project.compileSourceRoots}", required = true )
     private List<String> compileSourceRoots;
 
     /**

--- a/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
@@ -69,7 +69,7 @@ public class TestCompilerMojo
     /**
      * The source directories containing the test-source to be compiled.
      */
-    @Parameter ( defaultValue = "${project.testCompileSourceRoots}", readonly = true, required = true )
+    @Parameter ( defaultValue = "${project.testCompileSourceRoots}", required = true )
     private List<String> compileSourceRoots;
 
     /**


### PR DESCRIPTION
This fixes [MCOMPILER-417](https://issues.apache.org/jira/browse/MCOMPILER-417) only in part of documenting _compileSourceRoots_ parameters in site page (and in `:help` goal).