### PR TITLE
(doc) Fix typo and follow xml block style used for other parameters

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -391,27 +391,28 @@ public abstract class AbstractCompilerMojo
 
     /**
      * <p>
-     * Specify the requirements for this jdk toolchain for using a different {@code javac} then the one of the JRE used
+     * Specify the requirements for this jdk toolchain for using a different {@code javac} than the one of the JRE used
      * by Maven. This overrules the toolchain selected by the
      * <a href="https://maven.apache.org/plugins/maven-toolchains-plugin/">maven-toolchain-plugin</a>.
      * </p>
      * (see <a href="https://maven.apache.org/guides/mini/guide-using-toolchains.html"> Guide to Toolchains</a> for more
      * info)
      * 
-     * <pre>   {@code <configuration>
-     *        <jdkToolchain>
-     *            <version>11</version>
-     *        </jdkToolchain>
-     *        ...
-     *    </configuration>
+     * <pre>
+     * &lt;configuration&gt;
+     *   &lt;jdkToolchain&gt;
+     *     &lt;version&gt;11&lt;/version&gt;
+     *   &lt;/jdkToolchain&gt;
+     *   ...
+     * &lt;/configuration&gt;
      *
-     *    <configuration>
-     *        <jdkToolchain>
-     *            <version>1.8</version>
-     *            <vendor>zulu</vendor>
-     *        </jdkToolchain>
-     *        ...
-     *    </configuration>}
+     * &lt;configuration&gt;
+     *   &lt;jdkToolchain&gt;
+     *     &lt;version&gt;1.8&lt;/version&gt;
+     *     &lt;vendor&gt;zulu&lt;/vendor&gt;
+     *   &lt;/jdkToolchain&gt;
+     *   ...
+     * &lt;/configuration&gt;
      * </pre>
      * <strong>note:</strong> requires at least Maven 3.3.1
      * 


### PR DESCRIPTION
| before | after |
|---|---|
| ![mcp-tc-m](https://user-images.githubusercontent.com/11896137/152641433-51b54ac5-058e-4d37-86f1-276e15ab6531.png) | ![mcp-tc-pr](https://user-images.githubusercontent.com/11896137/152641441-9594e621-8469-4714-932b-33f1eaabda85.png) |



