### PR TITLE
[MCOMPILER-485] Fixes internal string format in generated package-info.class

### DIFF
--- a/src/it/MCOMPILER-485/invoker.properties
+++ b/src/it/MCOMPILER-485/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean compile
+invoker.buildResult = success

--- a/src/it/MCOMPILER-485/pom.xml
+++ b/src/it/MCOMPILER-485/pom.xml
@@ -1,0 +1,44 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>blah</groupId>
+  <artifactId>blah</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>@pom.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/MCOMPILER-485/src/main/java/dummy/HelloWorld.java
+++ b/src/it/MCOMPILER-485/src/main/java/dummy/HelloWorld.java
@@ -1,0 +1,28 @@
+package dummy;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+public class HelloWorld
+{
+   public static void main(String[] argv) {
+      System.out.println("Hello World");
+   }
+}

--- a/src/it/MCOMPILER-485/src/main/java/dummy/package-info.java
+++ b/src/it/MCOMPILER-485/src/main/java/dummy/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This is the package javadoc
+ */
+package dummy;

--- a/src/it/MCOMPILER-485/verify.groovy
+++ b/src/it/MCOMPILER-485/verify.groovy
@@ -1,0 +1,24 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+def packageInfoClassFile = new File( basedir, 'target/classes/dummy/package-info.class' )
+def packageInfoBytes = packageInfoClassFile.bytes
+def packageInfoHex = packageInfoBytes.encodeHex().toString()
+// "dummy/package-info" hex encoded
+assert packageInfoHex.contains( '64756d6d792f7061636b6167652d696e666f' )

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -1363,12 +1363,16 @@ public abstract class AbstractCompilerMojo
     private byte[] generatePackage( CompilerConfiguration compilerConfiguration, String javaFile )
     {
         int version = getOpcode( compilerConfiguration );
+        String internalPackageName = javaFile.substring( 0, javaFile.length() - ".java".length() );
+        if ( File.separatorChar != '/' )
+        {
+            internalPackageName = internalPackageName.replace( File.separatorChar, '/' );
+        }
         ClassWriter cw = new ClassWriter( 0 );
         cw.visitSource( "package-info.java", null );
         cw.visit( version,
                 Opcodes.ACC_SYNTHETIC | Opcodes.ACC_ABSTRACT | Opcodes.ACC_INTERFACE,
-                javaFile.substring( 0, javaFile.length() - ".java".length() ),
-                null, "java/lang/Object", null );
+                internalPackageName, null, "java/lang/Object", null );
         return cw.toByteArray();
     }
 

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -1369,10 +1369,10 @@ public abstract class AbstractCompilerMojo
             internalPackageName = internalPackageName.replace( File.separatorChar, '/' );
         }
         ClassWriter cw = new ClassWriter( 0 );
-        cw.visitSource( "package-info.java", null );
         cw.visit( version,
                 Opcodes.ACC_SYNTHETIC | Opcodes.ACC_ABSTRACT | Opcodes.ACC_INTERFACE,
                 internalPackageName, null, "java/lang/Object", null );
+        cw.visitSource( "package-info.java", null );
         return cw.toByteArray();
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MCOMPILER-485

[Per JVMS 4.2.1](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.2.1), the package name representation in the internal class structure always contains forward slashes in place of periods.  This PR fixes the code from MCOMPILER-205 which passed a package name extracted from the file path which used backward slashes on Windows.

While not necessarily a cause of the bug, the [javadocs for `ClassVisitor`](https://asm.ow2.io/javadoc/org/objectweb/asm/ClassVisitor.html) (the superclass of `ClassWriter`) state "The methods of this class must be called in the following order: visit visitSource ..." so I reordered those method calls as well.

The IT is copied from MCOMPILER-205 but with a more detailed test to confirm the correct internal representation of the package name in the class file.

`mvn -Prun-its clean verify` after the first (IT) commit finds the failure; note the 5c (`\`) on windows vs. 2f (`/`).
```text
Running post-build script: C:\Users\dawiddis.REDMOND\git\maven-compiler-plugin\target\it\MCOMPILER-485\verify.groovy
Assertion failed:

assert packageInfoHex.contains( '64756d6d792f7061636b6167652d696e666f' )
       |              |          d u m m y / p a c k a g e - i n f o 
       |              false
       cafebabe0000003400070100117061636b6167652d696e666f2e6a61766101001264756d6d795c7061636b6167652d696e666f0700020100106a61 ...
                                                                         d u m m y \ p a c k a g e - i n f o
```																		 
After code fix, passes tests:
```
[INFO] Building: MCOMPILER-485\pom.xml
[INFO] run post-build script verify.groovy
[INFO]           MCOMPILER-485\pom.xml ............................ SUCCESS (3.0 s)
```

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MCOMPILER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MCOMPILER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MCOMPILER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

