### PR TITLE
[MCOMPILER-347] Set Xcludes in config passed to actual compiler

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -953,6 +953,10 @@ public abstract class AbstractCompilerMojo
 
         compilerConfiguration.setModulepathEntries( getModulepathElements() );
         
+        compilerConfiguration.setIncludes( getIncludes() );
+
+        compilerConfiguration.setExcludes( getExcludes() );
+
         Map<String, String> effectiveCompilerArguments = getCompilerArguments();
 
         String effectiveCompilerArgument = getCompilerArgument();
@@ -1481,6 +1485,10 @@ public abstract class AbstractCompilerMojo
 
         return compileSources;
     }
+
+    protected abstract Set<String> getIncludes();
+
+    protected abstract Set<String> getExcludes();
 
     /**
      * @param compilerConfiguration

--- a/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
@@ -204,6 +204,18 @@ public class CompilerMojo
     }
 
     @Override
+    protected Set<String> getIncludes()
+    {
+        return includes;
+    }
+
+    @Override
+    protected Set<String> getExcludes()
+    {
+        return excludes;
+    }
+
+    @Override
     protected void preparePaths( Set<File> sourceFiles )
     {
         //assert compilePath != null;

--- a/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
@@ -497,4 +497,16 @@ public class TestCompilerMojo
         return true;
     }
 
+    @Override
+    protected Set<String> getIncludes()
+    {
+        return testIncludes;
+    }
+
+    @Override
+    protected Set<String> getExcludes()
+    {
+        return testExcludes;
+    }
+
 }


### PR DESCRIPTION
Fixes [MCOMPILER-347: Includes and excludes not passed into CompilerConfiguration](https://issues.apache.org/jira/browse/MCOMPILER-347)