### PR TITLE
[MCOMPILER-488] dedicated option for `implicit` javac flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@ under the License.
       ! The following property is used in the integration tests MCOMPILER-157
     -->
     <mavenPluginPluginVersion>3.5</mavenPluginPluginVersion>
-    <plexusCompilerVersion>2.11.1</plexusCompilerVersion>
+    <plexusCompilerVersion>2.11.2-SNAPSHOT</plexusCompilerVersion>
 
     <groovyVersion>2.4.21</groovyVersion>
     <groovyEclipseCompilerVersion>3.7.0</groovyEclipseCompilerVersion>

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -403,6 +403,14 @@ public abstract class AbstractCompilerMojo
     private String debuglevel;
 
     /**
+     * Keyword to be appended to the <code>-implicit:</code> command-line switch.
+     *
+     * @since 3.10.2
+     */
+    @Parameter( property = "maven.compiler.implicit" )
+    private String implicit;
+
+    /**
      *
      */
     @Component
@@ -685,6 +693,8 @@ public abstract class AbstractCompilerMojo
         compilerConfiguration.setDebug( debug );
 
         compilerConfiguration.setDebugFileName( getDebugFileName() );
+
+        compilerConfiguration.setImplicitOption( implicit );
 
         if ( debug && StringUtils.isNotEmpty( debuglevel ) )
         {
@@ -1909,5 +1919,10 @@ public abstract class AbstractCompilerMojo
     {
         this.release = release;
         targetOrReleaseSet = true;
+    }
+
+    final String getImplicit()
+    {
+        return implicit;
     }
 }

--- a/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTestCase.java
+++ b/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTestCase.java
@@ -267,6 +267,22 @@ public class CompilerMojoTestCase
         assertEquals( Arrays.asList( "key1=value1","-Xlint","-my&special:param-with+chars/not>allowed_in_XML_element_names" ), compileMojo.compilerArgs );
     }
 
+    public void testImplicitFlagNone()
+        throws Exception
+    {
+        CompilerMojo compileMojo = getCompilerMojo( "target/test-classes/unit/compiler-implicit-test/plugin-config-none.xml" );
+
+        assertEquals( "none", compileMojo.getImplicit() );
+    }
+
+    public void testImplicitFlagNotSet()
+        throws Exception
+    {
+        CompilerMojo compileMojo = getCompilerMojo( "target/test-classes/unit/compiler-implicit-test/plugin-config-not-set.xml" );
+
+        assertNull( compileMojo.getImplicit() );
+    }
+
     public void testOneOutputFileForAllInput2()
         throws Exception
     {

--- a/src/test/resources/unit/compiler-implicit-test/plugin-config-none.xml
+++ b/src/test/resources/unit/compiler-implicit-test/plugin-config-none.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compileSourceRoots>
+            <compileSourceRoot>${basedir}/target/test-classes/unit/compiler-implicit-test/src/main/java</compileSourceRoot>
+          </compileSourceRoots>
+          <compilerId>javac</compilerId>
+          <debug>true</debug>
+          <outputDirectory>${basedir}/target/test/unit/compiler-implicit-test/target/classes</outputDirectory>
+          <buildDirectory>${basedir}/target/test/unit/compiler-implicit-test/target</buildDirectory>
+          <implicit>none</implicit>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/compiler-implicit-test/plugin-config-not-set.xml
+++ b/src/test/resources/unit/compiler-implicit-test/plugin-config-not-set.xml
@@ -1,0 +1,37 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compileSourceRoots>
+            <compileSourceRoot>${basedir}/target/test-classes/unit/compiler-implicit-test/src/main/java</compileSourceRoot>
+          </compileSourceRoots>
+          <compilerId>javac</compilerId>
+          <debug>true</debug>
+          <outputDirectory>${basedir}/target/test/unit/compiler-implicit-test/target/classes</outputDirectory>
+          <buildDirectory>${basedir}/target/test/unit/compiler-implicit-test/target</buildDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Needs
- https://github.com/codehaus-plexus/plexus-compiler/pull/202

or similar.

- [MCOMPILER-488](https://issues.apache.org/jira/browse/MCOMPILER-488)