### PR TITLE
[MCOMPILER-501] compileSourceRoots parameter should be writable 

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
@@ -65,7 +65,7 @@ public class CompilerMojo
     /**
      * The source directories containing the sources to be compiled.
      */
-    @Parameter( defaultValue = "${project.compileSourceRoots}", readonly = true, required = true )
+    @Parameter( defaultValue = "${project.compileSourceRoots}", readonly = false, required = true )
     private List<String> compileSourceRoots;
 
     /**


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/MCOMPILER-501

When using multi-release JARs, the way is to configure the plugin, see https://github.com/apache/maven-compiler-plugin/blob/master/src/it/multirelease-patterns/singleproject-runtime/pom.xml#L92-L111

This causes a warning because the parameter is set as read-only.