### PR TITLE
[MCOMPILER-391] Use dep mgmt when resolving annotation processors and their deps

### DIFF
--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-api/pom.xml
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-api/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.compiler.it</groupId>
+    <artifactId>mcompiler391-test</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mcompiler391-annotation-api</artifactId>
+
+</project>

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-api/src/main/java/mcompiler391/SimpleAnnotation.java
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-api/src/main/java/mcompiler391/SimpleAnnotation.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package mcompiler391;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface SimpleAnnotation {
+    /**
+     * Specifies which class (FQCN) is supposed to be on classpath during annotation processing.
+     * Used to check if the dependency resolution mechanism of maven-compiler-plugin is constructing
+     * the classpath (processorpath) correctly, based on the plugin configuration and dependency management.
+     */
+    String onClasspath() default "";
+}

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-processor-dep-v1/pom.xml
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-processor-dep-v1/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.compiler.it</groupId>
+    <artifactId>mcompiler391-test</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mcompiler391-annotation-processor-dep</artifactId>
+
+</project>

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-processor-dep-v1/src/main/java/mcompiler391/AnnotationProcessorDependencyV1.java
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-processor-dep-v1/src/main/java/mcompiler391/AnnotationProcessorDependencyV1.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package mcompiler391;
+
+public class AnnotationProcessorDependencyV1 {}

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-processor-dep-v2/pom.xml
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-processor-dep-v2/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.compiler.it</groupId>
+    <artifactId>mcompiler391-test</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <!-- Same groupId + artifactId as for v1 (1.0.0-SNAPSHOT), but different version to test version overrides
+       via dependency management -->
+  <artifactId>mcompiler391-annotation-processor-dep</artifactId>
+  <version>2.0.0-SNAPSHOT</version>
+
+</project>

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-processor-dep-v2/src/main/java/mcompiler391/AnnotationProcessorDependencyV2.java
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-processor-dep-v2/src/main/java/mcompiler391/AnnotationProcessorDependencyV2.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package mcompiler391;
+
+public class AnnotationProcessorDependencyV2 {}

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-processor/pom.xml
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-processor/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.compiler.it</groupId>
+    <artifactId>mcompiler391-test</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mcompiler391-annotation-processor</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.plugins.compiler.it</groupId>
+      <artifactId>mcompiler391-annotation-api</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugins.compiler.it</groupId>
+      <artifactId>mcompiler391-annotation-processor-dep</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-processor/src/main/java/mcompiler391/SimpleAnnotationProcessor.java
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-processor/src/main/java/mcompiler391/SimpleAnnotationProcessor.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package mcompiler391;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Set;
+
+@SupportedSourceVersion(SourceVersion.RELEASE_6)
+@SupportedAnnotationTypes("mcompiler391.SimpleAnnotation")
+public class SimpleAnnotationProcessor extends AbstractProcessor {
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (annotations.isEmpty()) {
+            return true;
+        }
+
+        Filer filer = processingEnv.getFiler();
+
+        Elements elementUtils = processingEnv.getElementUtils();
+
+        Set<? extends Element> elements =
+                roundEnv.getElementsAnnotatedWith(annotations.iterator().next());
+
+        for (Element element : elements) {
+            Name name = element.getSimpleName();
+            PackageElement packageElement = elementUtils.getPackageOf(element);
+
+            SimpleAnnotation annotation = element.getAnnotation(SimpleAnnotation.class);
+            assertThatClassIsOnClasspath(annotation.onClasspath());
+
+            try {
+                Name packageName = packageElement.getQualifiedName();
+                FileObject resource =
+                        filer.createResource(StandardLocation.SOURCE_OUTPUT, packageName, name + ".txt", element);
+
+                Writer writer = resource.openWriter();
+                writer.write(name.toString());
+                writer.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return !elements.isEmpty();
+    }
+
+    private void assertThatClassIsOnClasspath(String fqcn) {
+        try {
+            getClass().getClassLoader().loadClass(fqcn);
+        } catch (ClassNotFoundException cnfe) {
+            String msg =
+                    String.format("Expected class '%s' to be on the classpath (processorpath), but it wasn't.", fqcn);
+            throw new RuntimeException(msg, cnfe);
+        }
+    }
+}

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user1/pom.xml
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user1/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.compiler.it</groupId>
+    <artifactId>mcompiler391-test</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mcompiler391-annotation-user1</artifactId>
+  <name>Annotation processor version from depMgmt + useDepMgmt=false</name>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.plugins.compiler.it</groupId>
+        <artifactId>mcompiler391-annotation-processor</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.plugins.compiler.it</groupId>
+      <artifactId>mcompiler391-annotation-api</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessors>
+            <annotationProcessor>mcompiler391.SimpleAnnotationProcessor</annotationProcessor>
+          </annotationProcessors>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.apache.maven.plugins.compiler.it</groupId>
+              <artifactId>mcompiler391-annotation-processor</artifactId>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins.compiler.it</groupId>
+        <artifactId>annotation-verify-plugin</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <id>verify-annotations</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>read-source</goal>
+            </goals>
+            <configuration>
+              <sourceClass>mcompiler391.SimpleObject1</sourceClass>
+              <testSourceClass>mcompiler391.SimpleTestObject1</testSourceClass>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user1/src/main/java/mcompiler391/SimpleObject1.java
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user1/src/main/java/mcompiler391/SimpleObject1.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package mcompiler391;
+
+@SimpleAnnotation(onClasspath = "mcompiler391.AnnotationProcessorDependencyV1")
+public class SimpleObject1 {}

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user1/src/test/java/mcompiler391/SimpleTestObject1.java
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user1/src/test/java/mcompiler391/SimpleTestObject1.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package mcompiler391;
+
+@SimpleAnnotation(onClasspath = "mcompiler391.AnnotationProcessorDependencyV1")
+public class SimpleTestObject1 {}

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user2/pom.xml
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user2/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.compiler.it</groupId>
+    <artifactId>mcompiler391-test</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mcompiler391-annotation-user2</artifactId>
+  <name>Annotation processor version from depMgmt + useDepMgmt=true</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.plugins.compiler.it</groupId>
+      <artifactId>mcompiler391-annotation-api</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.plugins.compiler.it</groupId>
+        <artifactId>mcompiler391-annotation-processor</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <!-- Overrides the version defined by mcompiler391-annotation-processor itself -->
+        <groupId>org.apache.maven.plugins.compiler.it</groupId>
+        <artifactId>mcompiler391-annotation-processor-dep</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessors>
+            <annotationProcessor>mcompiler391.SimpleAnnotationProcessor</annotationProcessor>
+          </annotationProcessors>
+          <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.apache.maven.plugins.compiler.it</groupId>
+              <artifactId>mcompiler391-annotation-processor</artifactId>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins.compiler.it</groupId>
+        <artifactId>annotation-verify-plugin</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <id>verify-annotations</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>read-source</goal>
+            </goals>
+            <configuration>
+              <sourceClass>mcompiler391.SimpleObject2</sourceClass>
+              <testSourceClass>mcompiler391.SimpleTestObject2</testSourceClass>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user2/src/main/java/mcompiler391/SimpleObject2.java
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user2/src/main/java/mcompiler391/SimpleObject2.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package mcompiler391;
+
+@SimpleAnnotation(onClasspath = "mcompiler391.AnnotationProcessorDependencyV2")
+public class SimpleObject2 {}

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user2/src/test/java/mcompiler391/SimpleTestObject2.java
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user2/src/test/java/mcompiler391/SimpleTestObject2.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package mcompiler391;
+
+@SimpleAnnotation(onClasspath = "mcompiler391.AnnotationProcessorDependencyV2")
+public class SimpleTestObject2 {}

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user3/pom.xml
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user3/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.compiler.it</groupId>
+    <artifactId>mcompiler391-test</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mcompiler391-annotation-user3</artifactId>
+  <name>Annotation processor version explicitly set + useDepMgmt=false</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.plugins.compiler.it</groupId>
+      <artifactId>mcompiler391-annotation-api</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessors>
+            <annotationProcessor>mcompiler391.SimpleAnnotationProcessor</annotationProcessor>
+          </annotationProcessors>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.apache.maven.plugins.compiler.it</groupId>
+              <artifactId>mcompiler391-annotation-processor</artifactId>
+              <version>1.0.0-SNAPSHOT</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins.compiler.it</groupId>
+        <artifactId>annotation-verify-plugin</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <id>verify-annotations</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>read-source</goal>
+            </goals>
+            <configuration>
+              <sourceClass>mcompiler391.SimpleObject3</sourceClass>
+              <testSourceClass>mcompiler391.SimpleTestObject3</testSourceClass>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user3/src/main/java/mcompiler391/SimpleObject3.java
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user3/src/main/java/mcompiler391/SimpleObject3.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package mcompiler391;
+
+@SimpleAnnotation(onClasspath = "mcompiler391.AnnotationProcessorDependencyV1")
+public class SimpleObject3 {}

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user3/src/test/java/mcompiler391/SimpleTestObject3.java
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user3/src/test/java/mcompiler391/SimpleTestObject3.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package mcompiler391;
+
+@SimpleAnnotation(onClasspath = "mcompiler391.AnnotationProcessorDependencyV1")
+public class SimpleTestObject3 {}

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user4/pom.xml
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user4/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.compiler.it</groupId>
+    <artifactId>mcompiler391-test</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mcompiler391-annotation-user4</artifactId>
+  <name>Annotation processor version explicitly set + useDepMgmt=true</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.plugins.compiler.it</groupId>
+      <artifactId>mcompiler391-annotation-api</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <!-- Overrides the version defined by mcompiler391-annotation-processor itself -->
+        <groupId>org.apache.maven.plugins.compiler.it</groupId>
+        <artifactId>mcompiler391-annotation-processor-dep</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessors>
+            <annotationProcessor>mcompiler391.SimpleAnnotationProcessor</annotationProcessor>
+          </annotationProcessors>
+          <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.apache.maven.plugins.compiler.it</groupId>
+              <artifactId>mcompiler391-annotation-processor</artifactId>
+              <version>1.0.0-SNAPSHOT</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins.compiler.it</groupId>
+        <artifactId>annotation-verify-plugin</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <id>verify-annotations</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>read-source</goal>
+            </goals>
+            <configuration>
+              <sourceClass>mcompiler391.SimpleObject4</sourceClass>
+              <testSourceClass>mcompiler391.SimpleTestObject4</testSourceClass>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user4/src/main/java/mcompiler391/SimpleObject4.java
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user4/src/main/java/mcompiler391/SimpleObject4.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package mcompiler391;
+
+@SimpleAnnotation(onClasspath = "mcompiler391.AnnotationProcessorDependencyV2")
+public class SimpleObject4 {}

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user4/src/test/java/mcompiler391/SimpleTestObject4.java
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/annotation-user4/src/test/java/mcompiler391/SimpleTestObject4.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package mcompiler391;
+
+@SimpleAnnotation(onClasspath = "mcompiler391.AnnotationProcessorDependencyV2")
+public class SimpleTestObject4 {}

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/invoker.properties
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals=process-test-classes

--- a/src/it/MCOMPILER-391-processorpath-dep-mgmt/pom.xml
+++ b/src/it/MCOMPILER-391-processorpath-dep-mgmt/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.compiler.it</groupId>
+  <artifactId>mcompiler391-test</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <url>https://issues.apache.org/jira/browse/MCOMPILER-391</url>
+
+  <modules>
+    <module>annotation-api</module>
+    <module>annotation-processor-dep-v1</module>
+    <module>annotation-processor-dep-v2</module>
+    <module>annotation-processor</module>
+    <module>annotation-user1</module>
+    <module>annotation-user2</module>
+    <module>annotation-user3</module>
+    <module>annotation-user4</module>
+  </modules>
+
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>@project.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>
+


### PR DESCRIPTION
 * dependency managemet can be used for two slighty difference use
   cases (when it comes to annotation processors):
     -- getting the version of the top-level processor path elements
     -- passing the list of managed dependencies to maven-resolver
        when resolving the whole processorpath
   These two can be combined, so there is total of 4 valid combinations
   (some of them make more sense than the others, but generally there is
   no reason to not support all of them)

 * using dependency management when resolving transitive dependencies of
   annotation processors is something that may or may not be desired.
   For that reason, there is a new flag that explicitly enables this
   behavior, while default is to _not_ use dependency management
   (the current behavior)

 * do not be scared by the the number of new lines. 95% of that are ITs, and of that like 50% are license headers :smile: 

These are the 4 use cases I am considering as part of this PR:
1. Version of the annotation processor path is explicitly set + useDepMgmt flag = false (default) -- the current behavior, dependency management is not used at all

2. Version of the annotation processor path is explicitly set + useDepMgmt flag = true (this may make the least sense of the combinations, but I see no reason to not allow it)

3. Version of the annotation processor dep is taken from dep mgmt + useDepMgmt flag = false (dep mgmt is when resolving the whole processorpath).

4. Version of the annotation processor dep is taken from dep mgmt + useDepMgmt flag= true (dep mgmt used when resolving the whole processorpath)

Note: the whole logic around annotation processor paths is getting bit out of hand (read more complex) and I think it would make sense to extract this into a separate class. I did want to complicate this PR further though, so that would be something for next PR(s).


Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MCOMPILER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MCOMPILER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MCOMPILER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

