### PR TITLE
Remove references to old Maven versions.

### DIFF
--- a/src/site/apt/examples/module-info.apt.vm
+++ b/src/site/apt/examples/module-info.apt.vm
@@ -54,8 +54,8 @@ Older projects with module-info
   In case you want the project to be Java 6, 7 or 8 compatible, you can simply use JDK 9 for both execution blocks.
 
   The easiest way is to use Java 9 as the runtime for Maven, by setting <<<JAVA_HOME=/path/to/jdk-9>>> before running <<<mvn>>>.
-  But if you want to use an older Java runtime for Maven, you can use the maven-toolchain-plugin to specify the shared JDK (supported since Maven 2.0.9)
-  or a custom jdkToolchain (supported since Maven 3.3.1) and refer to the JDK 9 installation on your system.  
+  But if you want to use an older Java runtime for Maven, you can use the maven-toolchain-plugin to specify the shared JDK
+  or a custom jdkToolchain and refer to the JDK 9 installation on your system.  
 
 +-------
 <project>

--- a/src/site/apt/examples/module-info.apt.vm
+++ b/src/site/apt/examples/module-info.apt.vm
@@ -106,10 +106,9 @@ Older projects with module-info
 
 * Java 5 or below Compatibility
 
-  Given Maven 3 requires newer Java release at runtime, you'll absolutely need to use Toolchains to use a JDK different from
+  Given that Maven 3 requires newer Java release at runtime, you'll absolutely need to use Toolchains to use a JDK different from
   Maven runtime.
 
-  Be aware that you will need at least Maven 3.3.1 to specify a custom jdkToolchain in your plugin configuration.
   You could add a jdkToolchain to do base-compile execution-block as well referring to JDK 5. 
 
 +-------


### PR DESCRIPTION
 In 2023 assume everyone is on 3.3.1 or later.
