### PR TITLE
[MCOMPILER-548] JDK 21 throws annotations processing warning that can not be turned off

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -294,7 +294,10 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
      * <ul>
      * <li><code>none</code> - no annotation processing is performed.</li>
      * <li><code>only</code> - only annotation processing is done, no compilation.</li>
+     * <li><code>full</code> - annotation processing and compilation.</li>
      * </ul>
+     *
+     * <code>full</code> is the default. Starting with JDK 21, this option must be set explicitly.
      *
      * @since 2.2
      * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html#option-proc">javac -proc</a>

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -303,7 +303,7 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
      * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html#option-proc">javac -proc</a>
      * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html#annotation-processing">javac Annotation Processing</a>
      */
-    @Parameter
+    @Parameter(property = "maven.compiler.proc")
     private String proc;
 
     /**


### PR DESCRIPTION
Turns out this is just a documentation issue. `full` works fine but is
not documented.

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MCOMPILER-548) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue.  Your pull request should address just this issue, without
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MCOMPILER-548] - Fixes bug in ApproximateQuantiles`,
       where you replace `MCOMPILER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
