### PR TITLE
[MCOMPILER-558] compileSourceRoots in testCompile should be writable

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
@@ -70,7 +70,7 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
     /**
      * The source directories containing the test-source to be compiled.
      */
-    @Parameter(defaultValue = "${project.testCompileSourceRoots}", readonly = true, required = true)
+    @Parameter(defaultValue = "${project.testCompileSourceRoots}", readonly = false, required = true)
     private List<String> compileSourceRoots;
 
     /**


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/MCOMPILER-558

Projects should be able to configure the `compileSourceRoots` also in the `testCompile` goal (like in the `compile` goal)

This causes a warning because the parameter is set as read-only.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

