### PR TITLE
[MCOMPILER-562] Add property maven.compiler.outputDirectory to CompilerMojo

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
@@ -83,7 +83,11 @@ public class CompilerMojo extends AbstractCompilerMojo {
      * it is recommended to use the {@code <release>} property
      * in conjunction with the ${multiReleaseOutput} parameter instead.
      */
-    @Parameter(property = "maven.compiler.outputDirectory", defaultValue = "${project.build.outputDirectory}", required = true, readonly = false)
+    @Parameter(
+            property = "maven.compiler.outputDirectory",
+            defaultValue = "${project.build.outputDirectory}",
+            required = true,
+            readonly = false)
     private File outputDirectory;
 
     /**

--- a/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
@@ -83,7 +83,7 @@ public class CompilerMojo extends AbstractCompilerMojo {
      * it is recommended to use the {@code <release>} property
      * in conjunction with the ${multiReleaseOutput} parameter instead.
      */
-    @Parameter(defaultValue = "${project.build.outputDirectory}", required = true, readonly = false)
+    @Parameter(property = "maven.compiler.outputDirectory", defaultValue = "${project.build.outputDirectory}", required = true, readonly = false)
     private File outputDirectory;
 
     /**


### PR DESCRIPTION
Currently, the CompilerMojo relies on the `outputDirectory` parameter without allowing external configuration (e.g via commandline). This limits the flexibility of the plugin in certain build environments.

#### Proposed Solution:
The source code for the CompilerMojo has been modified to introduce a new property, `maven.compiler.outputDirectory`, which can be configured externally. This change will enable users to specify a custom output directory for the compiler, offering greater flexibility and customization in different build scenarios while retaining backward compatibility with the existing `outputDirectory` parameter.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

