### PR TITLE
(doc) Add new value accepted by `-proc:` option

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -280,6 +280,7 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
      * <ul>
      * <li><code>none</code> - no annotation processing is performed.</li>
      * <li><code>only</code> - only annotation processing is done, no compilation.</li>
+     * <li><code>full</code> - since JDK 21, annotation processing and compilation are done.</li>
      * </ul>
      *
      * @since 2.2


### PR DESCRIPTION
Without explicit `-proc`, `javac` complains about its future:

```
[INFO] Compiling 5 source files with javac [debug release 17] to target/test-classes
[INFO] Annotation processing is enabled because one or more processors were found
  on the class path. A future release of javac may disable annotation processing
  unless at least one processor is specified by name (-processor), or a search
  path is specified (--processor-path, --processor-module-path), or annotation
  processing is enabled explicitly (-proc:only, -proc:full).
  Use -Xlint:-options to suppress this message.
  Use -proc:none to disable annotation processing.
```

Current parameter's javadoc suggests that only `only` and `none` are allowed. This parameter however is not validated by m-compiler-p. This is also not validated by plexus-compiler.

-----

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
