### PR TITLE
Remove info about old versions

### DIFF
--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -28,9 +28,9 @@
 
 ${project.name}
 
-  The Compiler Plugin is used to compile the sources of your project. Since 3.0, the
-  default compiler is javax.tools.JavaCompiler (if you are using java 1.6) and is used to compile Java sources.
-  If you want to force the plugin using  <<<javac>>>, you must configure the plugin option {{{./compile-mojo.html#forceJavacCompilerUse}<<<forceJavacCompilerUse>>>}}.
+  The Compiler Plugin is used to compile the sources of your project. The
+  default compiler used to compile Java sources is javax.tools.JavaCompiler.
+  If you want to force the plugin to use  <<<javac>>>, you must configure the plugin option {{{./compile-mojo.html#forceJavacCompilerUse}<<<forceJavacCompilerUse>>>}}.
 
   Also note that at present the default <<<source>>> setting is <<<1.8>>> and the default <<<target>>>
   setting is <<<1.8>>>, independently of the JDK you run Maven with.
@@ -66,7 +66,7 @@ ${project.name}
   already contain the answer to your question as part of an older thread. Hence, it is also worth browsing/searching
   the {{{./mailing-lists.html}mail archive}}.
 
-  If you feel like the plugin is missing a feature or has a defect, you can fill a feature request or bug report in our
+  If you feel the plugin is missing a feature or has a defect, you can file a feature request or bug report in our
   {{{./issue-management.html}issue tracker}}. When creating a new issue, please provide a comprehensive description of your
   concern. Especially for fixing bugs it is crucial that the developers can reproduce your problem. For this reason,
   entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated.


### PR DESCRIPTION
Java 1.8 is now minimum, not Java 1.6.


