### PR TITLE
[MCOMPILER-591] testCompile - fix detections of target less than 1.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,8 +182,14 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.9.1</version>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.10.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -111,9 +111,6 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
 
     static final String DEFAULT_TARGET = "1.8";
 
-    // Used to compare with older targets
-    static final String MODULE_INFO_TARGET = "1.9";
-
     // ----------------------------------------------------------------------
     // Configurables
     // ----------------------------------------------------------------------

--- a/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
@@ -316,13 +316,13 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
             return;
         }
         if (StringUtils.isNotEmpty(getRelease())) {
-            if (Integer.parseInt(getRelease()) < 9) {
+            if (isOlderThanJDK9(getRelease())) {
                 pathElements = Collections.emptyMap();
                 modulepathElements = Collections.emptyList();
                 classpathElements = testPath;
                 return;
             }
-        } else if (Double.parseDouble(getTarget()) < Double.parseDouble(MODULE_INFO_TARGET)) {
+        } else if (isOlderThanJDK9(getTarget())) {
             pathElements = Collections.emptyMap();
             modulepathElements = Collections.emptyList();
             classpathElements = testPath;
@@ -434,6 +434,14 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
         }
 
         return scanner;
+    }
+
+    static boolean isOlderThanJDK9(String version) {
+        if (version.startsWith("1.")) {
+            return Integer.parseInt(version.substring(2)) < 9;
+        }
+
+        return Integer.parseInt(version) < 9;
     }
 
     protected String getSource() {

--- a/src/test/java/org/apache/maven/plugin/compiler/TestCompilerMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/compiler/TestCompilerMojoTest.java
@@ -24,11 +24,15 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.maven.plugin.compiler.stubs.CompilerManagerStub;
 import org.apache.maven.plugin.testing.junit5.InjectMojo;
 import org.apache.maven.plugin.testing.junit5.MojoTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.apache.maven.plugin.compiler.MojoTestUtils.getMockMavenProject;
 import static org.apache.maven.plugin.compiler.MojoTestUtils.getMockMavenSession;
@@ -185,5 +189,21 @@ class TestCompilerMojoTest {
         setVariableValueToObject(mojo, "mojoExecution", getMockMojoExecution());
         setVariableValueToObject(mojo, "source", AbstractCompilerMojo.DEFAULT_SOURCE);
         setVariableValueToObject(mojo, "target", AbstractCompilerMojo.DEFAULT_TARGET);
+    }
+
+    static Stream<Arguments> olderThanJDK9() {
+        return Stream.of(
+                Arguments.of("1.8", true),
+                Arguments.of("8", true),
+                Arguments.of("1.9", false),
+                Arguments.of("1.9", false),
+                Arguments.of("9", false),
+                Arguments.of("11", false));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void olderThanJDK9(String version, boolean expected) {
+        assertEquals(expected, TestCompilerMojo.isOlderThanJDK9(version));
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MCOMPILER-591