### PR TITLE
Remove Maven 3 note

### DIFF
--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -75,5 +75,3 @@ mvn test-compile
 </project>
 +-----
 
-  <<Note>>: Maven 3.0 will issue warnings if you do not specify the version of a
-  plugin.


### PR DESCRIPTION
Also we don't need generic info on this page that applies to all plugins rather than the maven-compiler-plugin specifically


