### PR TITLE
Cleanup usages of System.getProperty calls.

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -91,7 +91,7 @@ import org.objectweb.asm.Opcodes;
  * @since 2.0
  */
 public abstract class AbstractCompilerMojo implements Mojo {
-    protected static final String PS = System.getProperty("path.separator");
+    protected static final String PS = File.pathSeparator;
 
     private static final String INPUT_FILES_LST_FILENAME = "inputFiles.lst";
 
@@ -834,7 +834,7 @@ public abstract class AbstractCompilerMojo implements Mojo {
                     getLog().warn("You are in a multi-thread build and compilerReuseStrategy is set to reuseSame."
                             + " This can cause issues in some environments (os/jdk)!"
                             + " Consider using reuseCreated strategy."
-                            + System.getProperty("line.separator")
+                            + System.lineSeparator()
                             + "If your env is fine with reuseSame, you can skip this warning with the "
                             + "configuration field skipMultiThreadWarning "
                             + "or -Dmaven.compiler.skipMultiThreadWarning=true");

--- a/src/main/java/org/apache/maven/plugin/compiler/CompilationFailureException.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilationFailureException.java
@@ -29,7 +29,7 @@ import org.codehaus.plexus.compiler.CompilerMessage;
  */
 @SuppressWarnings("serial")
 public class CompilationFailureException extends MojoException {
-    private static final String LS = System.getProperty("line.separator");
+    private static final String LS = System.lineSeparator();
 
     /**
      * Wrap error messages from the compiler


### PR DESCRIPTION
No need to call System.getProperty with magic names 'path.separator' and 'line.separator'. Java does that for us and provides friendly methods/fields for them.