### PR TITLE
[MCOMPILER-592] don't validate the project.build.outputTimestamp

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -1152,8 +1152,8 @@ public abstract class AbstractCompilerMojo implements Mojo {
             }
         }
 
-        if (outputTimestamp != null
-                && !outputTimestamp.isEmpty()
+        // One chat like "x" in outputTimestamp may be used reset the value from a parent POM
+        if (StringUtils.isNotBlank(outputTimestamp)
                 && (outputTimestamp.length() > 1 || Character.isDigit(outputTimestamp.charAt(0)))) {
             // if Reproducible Builds mode, apply workaround
             patchJdkModuleVersion(compilerResult, sources);


### PR DESCRIPTION
The outputTimestamp is checked to be not shorter than one char or to be a digit. The parsing of the outputTimestamp in the maven-jar-plugin is more complicated. But it's not needed to be done in the compiler plugin at all so it would be safer to remove it. We already had an IndexOutOfBoundsException when the string is empty because of the useless validation.

This is a simplification of the #244

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MCOMPILER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MCOMPILER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MCOMPILER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

