### PR TITLE
Upgrade to Maven 4.0.0-rc-2.

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,7 +27,7 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
     with:
       # maven-args: "-Dinvoker.parallelThreads=2" cannot do this as this generate some concurrent download issues
-      ff-maven: "4.0.0-beta-5"                     # Maven version for fail-fast-build
+      ff-maven: "4.0.0-rc-2"                     # Maven version for fail-fast-build
       jdk-distribution-matrix: '[ "temurin", "zulu", "microsoft", "adopt-openj9" ]'
       jdk-matrix: '[ "17", "21" ]'
-      maven-matrix: '[ "4.0.0-beta-5" ]'  # Maven versions matrix for verify builds
+      maven-matrix: '[ "4.0.0-rc-2" ]'  # Maven versions matrix for verify builds

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@ under the License.
   <scm>
     <connection>scm:git:https://github.com/apache/maven-compiler-plugin.git</connection>
     <developerConnection>scm:git:https://github.com/apache/maven-compiler-plugin.git</developerConnection>
-    <tag>maven-compiler-plugin-3.10.0</tag>
+    <tag>HEAD</tag>
     <url>https://github.com/apache/maven-compiler-plugin/tree/${project.scm.tag}</url>
   </scm>
   <issueManagement>
@@ -82,22 +82,14 @@ under the License.
 
   <properties>
     <javaVersion>17</javaVersion>
-    <mavenVersion>4.0.0-beta-5</mavenVersion>
+    <mavenVersion>4.0.0-rc-2</mavenVersion>
 
     <asmVersion>9.7.1</asmVersion>
-    <groovyVersion>2.4.21</groovyVersion>
-    <groovyEclipseCompilerVersion>3.7.0</groovyEclipseCompilerVersion>
-    <groovy-eclipse-batch>2.5.14-02</groovy-eclipse-batch>
     <guiceVersion>6.0.0</guiceVersion>
-    <junit4Version>4.13.2</junit4Version>
-    <junitVersion>5.10.1</junitVersion>
-    <mockitoVersion>5.12.0</mockitoVersion>
-    <mavenPluginTestingHarnessVersion>4.0.0-beta-2</mavenPluginTestingHarnessVersion>
+    <mockitoVersion>5.14.2</mockitoVersion>
+    <mavenPluginTestingHarnessVersion>4.0.0-beta-3</mavenPluginTestingHarnessVersion>
     <plexusCompilerVersion>2.15.0</plexusCompilerVersion>
-    <plexusJavaVersion>1.2.0</plexusJavaVersion>
     <sisuPlexusVersion>0.9.0.M2</sisuPlexusVersion>
-    <surefire.version>3.2.1</surefire.version>
-    <version.maven-invoker-plugin>3.7.0</version.maven-invoker-plugin>
     <version.maven-plugin-tools-3.x>3.13.1</version.maven-plugin-tools-3.x>
     <version.maven-plugin-tools>4.0.0-beta-1</version.maven-plugin-tools>
 
@@ -129,13 +121,13 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-api-impl</artifactId>
+      <artifactId>maven-impl</artifactId>
       <version>${mavenVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-xml-impl</artifactId>
+      <artifactId>maven-xml</artifactId>
       <version>${mavenVersion}</version>
       <scope>test</scope>
     </dependency>

--- a/src/it/MCOMPILER-346/verify.groovy
+++ b/src/it/MCOMPILER-346/verify.groovy
@@ -17,12 +17,9 @@
  * under the License.
  */
 
-/*
- * Temporarily disabled, pending fix in Maven 4.0.0-beta-6.
 def logFile = new File( basedir, 'build.log' )
 assert logFile.exists()
 content = logFile.text
 
 assert content.contains( 'package org.jenkinsci.test.acceptance.controller does not exist' )
 assert content.contains( 'package org.jenkinsci.test.acceptance.log does not exist' )
-*/


### PR DESCRIPTION
* Upgrade to Maven 4.0.0-rc-2 and testing 4.0.0-beta-3.
* Revert "Temporarily disable the MCOMPILER-346 integration test".
* Remove version properties for dependencies that are not used anymore.
