### PR TITLE
Use JUnit version from parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,13 +182,11 @@ under the License.
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.10.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>5.10.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
In parent, we use bom for JUnit, so some of the artifacts can be in incompatibility version
