### PR TITLE
Rename property `moduleVersion` to `maven.compiler.moduleVersion`

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -122,7 +122,7 @@ public abstract class AbstractCompilerMojo implements Mojo {
      * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html#option-module-version">javac --module-version</a>
      * @since 4.0.0
      */
-    @Parameter(property = "moduleVersion", defaultValue = "${project.version}")
+    @Parameter(property = "maven.compiler.moduleVersion", defaultValue = "${project.version}")
     protected String moduleVersion;
 
     /**


### PR DESCRIPTION
It is a new parameter added in #271
