### PR TITLE
Add the ggeneratedSourcesPath to the project source roots again

### DIFF
--- a/src/it/setup_annotation-verify-plugin/src/main/java/org.apache.maven.plugins.compiler.it/SourcePathReadGoal.java
+++ b/src/it/setup_annotation-verify-plugin/src/main/java/org.apache.maven.plugins.compiler.it/SourcePathReadGoal.java
@@ -47,17 +47,12 @@ public class SourcePathReadGoal extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (sourceClass != null) {
             getLog().info("Checking compile source roots for: '" + sourceClass + "'");
-            List<String> roots = project.getCompileSourceRoots();
-            roots.add(project.getModel().getBuild().getOutputDirectory() + "/../generated-sources/annotations");
-            assertGeneratedSourceFileFor(sourceClass, roots);
+            assertGeneratedSourceFileFor(sourceClass, project.getCompileSourceRoots());
         }
 
         if (testSourceClass != null) {
             getLog().info("Checking test-compile source roots for: '" + testSourceClass + "'");
-            List<String> roots = project.getTestCompileSourceRoots();
-            roots.add(
-                    project.getModel().getBuild().getOutputDirectory() + "/../generated-test-sources/test-annotations");
-            assertGeneratedSourceFileFor(testSourceClass, roots);
+            assertGeneratedSourceFileFor(testSourceClass, project.getTestCompileSourceRoots());
         }
     }
 

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -824,6 +824,22 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
             }
         }
 
+        String generatedSourcesPath = generatedSourcesDirectory.getAbsolutePath();
+
+        if (isTestCompile()) {
+            getLog().debug("Adding " + generatedSourcesPath
+                    + " to the project test-compile source roots but NOT the actual test-compile source roots:\n  "
+                    + StringUtils.join(project.getTestCompileSourceRoots().iterator(), "\n  "));
+
+            project.addTestCompileSourceRoot(generatedSourcesPath);
+        } else {
+            getLog().debug("Adding " + generatedSourcesPath
+                    + " to the project compile source roots but NOT the actual compile source roots:\n  "
+                    + StringUtils.join(project.getCompileSourceRoots().iterator(), "\n  "));
+
+            project.addCompileSourceRoot(generatedSourcesPath);
+        }
+
         compilerConfiguration.setSourceLocations(compileSourceRoots);
 
         compilerConfiguration.setAnnotationProcessors(annotationProcessors);
@@ -1121,6 +1137,9 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
                         patchModules.add("_"); // this jar
                     } else if (getOutputDirectory().toPath().startsWith(filePath)) {
                         // multirelease, can be ignored
+                        continue;
+                    } else if (generatedSourcesDirectory.toPath().startsWith(filePath)) {
+                        // ignore generated sources
                         continue;
                     } else if (sourceRoots.contains(filePath)) {
                         patchModules.add("_"); // this jar

--- a/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
@@ -32,6 +32,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -182,7 +183,14 @@ public class CompilerMojo extends AbstractCompilerMojo {
 
     @Override
     protected List<String> getCompileSourceRoots() {
-        return compileSourceRoots;
+        if (generatedSourcesDirectory == null) {
+            return compileSourceRoots;
+        } else {
+            String generatedSourceRoot = generatedSourcesDirectory.getAbsolutePath();
+            return compileSourceRoots.stream()
+                    .filter(x -> !Objects.equals(x, generatedSourceRoot))
+                    .collect(Collectors.toList());
+        }
     }
 
     @Override

--- a/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
@@ -30,7 +30,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -209,7 +211,14 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
     }
 
     protected List<String> getCompileSourceRoots() {
-        return compileSourceRoots;
+        if (generatedTestSourcesDirectory == null) {
+            return compileSourceRoots;
+        } else {
+            String generatedSourceRoot = generatedTestSourcesDirectory.getAbsolutePath();
+            return compileSourceRoots.stream()
+                    .filter(x -> !Objects.equals(x, generatedSourceRoot))
+                    .collect(Collectors.toList());
+        }
     }
 
     @Override


### PR DESCRIPTION
Followup for #191 to add back the `generatedSourcesPath` to the maven project paths.

This seems to work, but the solution feels a bit hacky.

---

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. 
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. 
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
