### PR TITLE
Add generatedSourcesPath back to the maven project

### DIFF
--- a/src/it/setup_annotation-verify-plugin/src/main/java/org.apache.maven.plugins.compiler.it/SourcePathReadGoal.java
+++ b/src/it/setup_annotation-verify-plugin/src/main/java/org.apache.maven.plugins.compiler.it/SourcePathReadGoal.java
@@ -47,17 +47,12 @@ public class SourcePathReadGoal extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (sourceClass != null) {
             getLog().info("Checking compile source roots for: '" + sourceClass + "'");
-            List<String> roots = project.getCompileSourceRoots();
-            roots.add(project.getModel().getBuild().getOutputDirectory() + "/../generated-sources/annotations");
-            assertGeneratedSourceFileFor(sourceClass, roots);
+            assertGeneratedSourceFileFor(sourceClass, project.getCompileSourceRoots());
         }
 
         if (testSourceClass != null) {
             getLog().info("Checking test-compile source roots for: '" + testSourceClass + "'");
-            List<String> roots = project.getTestCompileSourceRoots();
-            roots.add(
-                    project.getModel().getBuild().getOutputDirectory() + "/../generated-test-sources/test-annotations");
-            assertGeneratedSourceFileFor(testSourceClass, roots);
+            assertGeneratedSourceFileFor(testSourceClass, project.getTestCompileSourceRoots());
         }
     }
 

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -703,8 +703,39 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
     private boolean targetOrReleaseSet;
 
     @Override
-    @SuppressWarnings("checkstyle:MethodLength")
     public void execute() throws MojoExecutionException, CompilationFailureException {
+        try {
+            executeReal();
+        } finally {
+            addGeneratedSourcesToProject();
+        }
+    }
+
+    private void addGeneratedSourcesToProject() {
+        File generatedSourcesDirectory = getGeneratedSourcesDirectory();
+        if (generatedSourcesDirectory == null) {
+            return;
+        }
+
+        String generatedSourcesPath = generatedSourcesDirectory.getAbsolutePath();
+
+        if (isTestCompile()) {
+            getLog().debug("Adding " + generatedSourcesPath
+                    + " to the project test-compile source roots but NOT the actual test-compile source roots:\n  "
+                    + StringUtils.join(project.getTestCompileSourceRoots().iterator(), "\n  "));
+
+            project.addTestCompileSourceRoot(generatedSourcesPath);
+        } else {
+            getLog().debug("Adding " + generatedSourcesPath
+                    + " to the project compile source roots but NOT the actual compile source roots:\n  "
+                    + StringUtils.join(project.getCompileSourceRoots().iterator(), "\n  "));
+
+            project.addCompileSourceRoot(generatedSourcesPath);
+        }
+    }
+
+    @SuppressWarnings("checkstyle:MethodLength")
+    private void executeReal() throws MojoExecutionException, CompilationFailureException {
         // ----------------------------------------------------------------------
         // Look up the compiler. This is done before other code than can
         // cause the mojo to return before the lookup is done possibly resulting


### PR DESCRIPTION
This is a followup for for #191 to add the generatedSourcesPath back to the maven project paths as the final step of the mojo.

This is an *alternative* implementation to #311.

---

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. 
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. 
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
