### PR TITLE
Bump org.apache.maven.plugins:maven-plugins from 43 to 44

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-plugins</artifactId>
-    <version>43</version>
+    <version>44</version>
     <relativePath />
   </parent>
 
@@ -88,7 +88,6 @@ under the License.
     <guiceVersion>6.0.0</guiceVersion>
     <mockitoVersion>5.17.0</mockitoVersion>
     <mavenPluginTestingHarnessVersion>4.0.0-beta-4</mavenPluginTestingHarnessVersion>
-    <plexusCompilerVersion>2.15.0</plexusCompilerVersion>
     <sisuPlexusVersion>0.9.0.M2</sisuPlexusVersion>
     <version.maven-plugin-tools-3.x>3.13.1</version.maven-plugin-tools-3.x>
     <version.maven-plugin-tools>4.0.0-beta-1</version.maven-plugin-tools>

--- a/src/test/java/org/apache/maven/plugin/compiler/stubs/CompilerStub.java
+++ b/src/test/java/org/apache/maven/plugin/compiler/stubs/CompilerStub.java
@@ -85,7 +85,7 @@ public class CompilerStub implements JavaCompiler, StandardJavaFileManager {
      *
      * @see #getOptions()
      */
-    private static final ThreadLocal<Iterable<String>> arguments = new ThreadLocal<>();
+    private static final ThreadLocal<Iterable<String>> ARGUMENTS = new ThreadLocal<>();
 
     /**
      * Invoked by reflection by {@link java.util.ServiceLoader}.
@@ -309,7 +309,7 @@ public class CompilerStub implements JavaCompiler, StandardJavaFileManager {
             Iterable<String> classes,
             Iterable<? extends JavaFileObject> compilationUnits) {
 
-        arguments.set(options);
+        ARGUMENTS.set(options);
         return new CompilationTask() {
             @Override
             public void addModules(Iterable<String> moduleNames) {}
@@ -354,7 +354,7 @@ public class CompilerStub implements JavaCompiler, StandardJavaFileManager {
      */
     public static List<String> getOptions() {
         var options = new ArrayList<String>();
-        Iterable<String> args = arguments.get();
+        Iterable<String> args = ARGUMENTS.get();
         if (args != null) {
             args.forEach(options::add);
         }


### PR DESCRIPTION
This is in replacement of #315 generated by dependabot. Upgrading the `maven-plugins` dependency is more work than just upgrading the version number, because:

* New errors are raised by Checkstyle.
* The `maven-dependency-plugin` is now executed (inherited from a new block in `maven-plugins`), and that execution fails if we do not delete the output files generated by the stub compiler. This is because those output files are not real `*.class` files.