### PR TITLE
Replace maven-plugin-testing-harness by maven-testing and remove sisuPlexusVersion property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,6 @@ under the License.
     <asmVersion>9.8</asmVersion>
     <guiceVersion>6.0.0</guiceVersion>
     <mockitoVersion>5.18.0</mockitoVersion>
-    <mavenPluginTestingHarnessVersion>4.0.0-beta-4</mavenPluginTestingHarnessVersion>
     <eclipseCompilerVersion>3.42.0</eclipseCompilerVersion>
     <version.maven-plugin-tools-3.x>3.13.1</version.maven-plugin-tools-3.x>
     <version.maven-plugin-tools>4.0.0-beta-1</version.maven-plugin-tools>
@@ -149,6 +148,12 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
+      <artifactId>maven-testing</artifactId>
+      <version>${mavenVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
       <artifactId>maven-xml</artifactId>
       <version>${mavenVersion}</version>
       <scope>test</scope>
@@ -157,12 +162,6 @@ under the License.
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
       <version>${guiceVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.plugin-testing</groupId>
-      <artifactId>maven-plugin-testing-harness</artifactId>
-      <version>${mavenPluginTestingHarnessVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
The testing framework has been integrated inside Maven Core [#10451](https://github.com/apache/maven/issues/10451).

`maven-testing` dependency can be used instead of `maven-plugin-testing-harness`.

The `sisuPlexusVersion` property declared in the pom is not used. There are two transitive dependencies regarding Eclipse Sisu with the test scope: `org.eclipse.sisu.inject` and `org.eclipse.sisu.plexus`. Currently on maven-compiler-plugin version 4.0.0-beta-3-SNAPSHOT, both of these dependencies are version 0.9.0.M4.
These dependencies appear as managed dependencies by the maven-parent pom and the property `version.sisu-maven-plugin`.

The `sisuPlexusVersion` property therefore does not seem necessary.