### PR TITLE
Fix for new Kotlin

### DIFF
--- a/src/it/MCOMPILER-567-kt/pom.xml
+++ b/src/it/MCOMPILER-567-kt/pom.xml
@@ -25,6 +25,10 @@
   <packaging>jar</packaging>
   <name>MCOMPILER-567-kt</name>
 
+  <properties>
+    <kotlin.compiler.daemon>false</kotlin.compiler.daemon>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
By default, it starts a daemon, but uses IT local repo, hence m-clean-p fails on Windows.

Kotlin was upped here: 52d922f9215fe52de51853d3635cbbc91b56f68a
Ref: https://kotlinlang.org/docs/kotlin-daemon.html