### PR TITLE
Do not fail fast

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -29,6 +29,7 @@ jobs:
       jdk-distribution-matrix: '[ "temurin", "zulu", "microsoft", "adopt-openj9" ]'
       maven4-build: true
       maven4-version: '4.0.0-rc-4' # the same as used in project
+      verify-fail-fast: false
       matrix-exclude: '[
         { "jdk": "25", "distribution": "adopt-openj9" },
         { "jdk": "25", "distribution": "microsoft"}     


### PR DESCRIPTION
By default the matrix will fail fast, but in this case it makes no sense, and is even better to make it non fail fast.

Ref:
https://github.com/apache/maven-gh-actions-shared/blob/3b6a3fd53a6cc1ea2f5f25625cc9fd6a9d6ebe22/.github/workflows/maven-verify.yml#L162
