### PR TITLE
Quote filenames written in shell scripts

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/Options.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/Options.java
@@ -404,11 +404,11 @@ public final class Options {
             }
             boolean needsQuote = option.indexOf(' ') >= 0;
             if (needsQuote) {
-                out.append('"');
+                out.append(AbstractCompilerMojo.QUOTE);
             }
             out.append(option);
             if (needsQuote) {
-                out.append('"');
+                out.append(AbstractCompilerMojo.QUOTE);
             }
             hasOptions = true;
         }

--- a/src/main/java/org/apache/maven/plugin/compiler/SourcePathType.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/SourcePathType.java
@@ -102,7 +102,7 @@ final class SourcePathType implements PathType {
      */
     @Override
     public String[] option(Iterable<? extends Path> paths) {
-        var joiner = new StringJoiner(File.pathSeparator, (moduleName != null) ? moduleName + "=\"" : "\"", "\"");
+        var joiner = new StringJoiner(File.pathSeparator, (moduleName != null) ? moduleName + '=' : "", "");
         paths.forEach((path) -> joiner.add(path.toString()));
         return new String[] {option().get(), joiner.toString()};
     }

--- a/src/main/java/org/apache/maven/plugin/compiler/WorkaroundForPatchModule.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/WorkaroundForPatchModule.java
@@ -120,7 +120,7 @@ final class WorkaroundForPatchModule extends ForwardingJavaFileManager<StandardJ
 
     /**
      * Sets a module path by asking the file manager to parse an option formatted by this method.
-     * Invoked when a module path cannot be specified through the API
+     * Invoked when a module path cannot be specified through the standard <abbr>API</abbr>.
      * This is the workaround described in class Javadoc.
      *
      * @param fileManager the file manager on which an attempt to set the location has been made and failed


### PR DESCRIPTION
Following https://github.com/apache/maven/pull/11435 (a change in Maven core for not quoting the files formatted by `JavaPathType` because filenames specified in `java.util.spi.ToolProvider` API shall *not* be quoted), quotes are added by the plugin instead, and only when the target is a shell script.

Opportunistically add a safety when path using only for debugging purposes cannot be relativized.