### PR TITLE
Remove declaration of "plexus-snapshots" repository in integration tests

### DIFF
--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -39,19 +39,6 @@ under the License.
             <checksumPolicy>ignore</checksumPolicy>
           </snapshots>
         </repository>
-        <repository>
-          <releases>
-            <enabled>false</enabled>
-            <checksumPolicy>ignore</checksumPolicy>
-          </releases>
-          <snapshots>
-            <enabled>true</enabled>
-            <checksumPolicy>ignore</checksumPolicy>
-          </snapshots>
-          <id>plexus-snapshots</id>
-          <name>Plexus Snapshot Repository</name>
-          <url>https://oss.sonatype.org/content/repositories/plexus-snapshots</url>
-        </repository>
       </repositories>
       <pluginRepositories>
         <pluginRepository>


### PR DESCRIPTION
As of December 21, the https://oss.sonatype.org/content/repositories/plexus-snapshots URL produces an HTTP error 503, which cause the `src/it/MCOMPILER-522-unresolvable-dependency/` integration test. That test contains the following dependency:

```xml
<annotationProcessorPaths>
  <path>
    <groupId>org.apache.maven.plugins.compiler.it</groupId>
    <artifactId>annotation-processor-non-existing</artifactId>
    <version>1.0-SNAPSHOT</version>
  </path>
</annotationProcessorPaths>
```

Because that dependency is not found on Maven central, it was searched on Plexus snapshots.