### PR TITLE
Remove unused dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,6 @@ under the License.
     <mavenVersion>4.0.0-rc-4</mavenVersion>
 
     <asmVersion>9.9.1</asmVersion>
-    <guiceVersion>6.0.0</guiceVersion>
     <mockitoVersion>5.21.0</mockitoVersion>
     <eclipseCompilerVersion>3.42.0</eclipseCompilerVersion>
     <version.maven-plugin-tools-3.x>3.13.1</version.maven-plugin-tools-3.x>
@@ -153,12 +152,6 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-testing</artifactId>
       <version>${mavenVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-      <version>${guiceVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
probably going to fail but let's make sure. Yep. definitely needed

Error:    CompilerMojoTestCase.testModularProject(CompilerMojo, TestCompilerMojo) » ParameterResolution Failed to resolve parameter [org.apache.maven.plugin.compiler.CompilerMojo arg0] in method [public void org.apache.maven.plugin.compiler.CompilerMojoTestCase.testModularProject(org.apache.maven.plugin.compiler.CompilerMojo,org.apache.maven.plugin.compiler.TestCompilerMojo)]: Could not initialize class org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup

Need to figure out why the dependency analyzer doesn't recognize this one.