### PR TITLE
Update maven-surefire-plugin version to 3.x in the MCOMPILER-481 IT

### DIFF
--- a/src/it/MCOMPILER-481-requires-static-included/app/pom.xml
+++ b/src/it/MCOMPILER-481-requires-static-included/app/pom.xml
@@ -39,7 +39,7 @@ under the License.
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util-ajax</artifactId>
-      <version>10.0.7</version>
+      <version>12.1.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/it/MCOMPILER-481-requires-static-included/app/pom.xml
+++ b/src/it/MCOMPILER-481-requires-static-included/app/pom.xml
@@ -45,7 +45,7 @@ under the License.
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.8.2</version>
+      <version>5.14.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/it/MCOMPILER-481-requires-static-included/pom.xml
+++ b/src/it/MCOMPILER-481-requires-static-included/pom.xml
@@ -43,16 +43,8 @@ under the License.
           <artifactId>maven-compiler-plugin</artifactId>
           <version>@project.version@</version>
           <configuration>
-            <source>11</source>
-            <target>11</target>
             <release>11</release>
           </configuration>
-        </plugin>
-        <plugin>
-          <!-- TODO: This IT fails with surefire 3.x -->
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.2</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/src/it/MCOMPILER-481-requires-static-included/service/pom.xml
+++ b/src/it/MCOMPILER-481-requires-static-included/service/pom.xml
@@ -33,7 +33,7 @@ under the License.
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util-ajax</artifactId>
-      <version>10.0.7</version>
+      <version>12.1.6</version>
       <optional>true</optional>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Resolve a TODO left in the MCOMPILER-481 integration test. There was a bug with maven-surefire-plugin 3.x which meant that the plugin version had to be set to 2.x in order for the test to pass (cf. #712). Starting with version 3.2.x of maven-surefire-plugin, this is no longer necessary.

This can be port to the master branch but since the MCOMPILER-481 issue relates to a plexus bug, i wonder if this IT is still relevant in the 4.x maven-compiler-plugin context. Maybe it is redondant with other ITs added in 4.x.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
