### PR TITLE
(docs) Add moditect-maven-plugin as it is a less complex way for Java 8 with java module descriptors

### DIFF
--- a/src/site/markdown/examples/module-info.md
+++ b/src/site/markdown/examples/module-info.md
@@ -25,6 +25,8 @@ there is nothing special to do.
 
 # Java 8 projects with module-info
 
+## Using the maven-compiler-plugin
+
 Projects that want to be compatible with older versions of Java (i.e, 8 or below bytecode and API),
 but also want to provide a `module-info.java` for use on Java 9+ runtime,
 must be aware that they need to call `javac` twice:
@@ -95,3 +97,56 @@ can be replaced by:
                 <version>1.8</version>
               </jdkToolchain>
 ```
+
+## Using the moditect-maven-plugin
+
+A clean way to generate the `module-info.class` file without compiling the sources twice
+is to use the [moditect-maven-plugin](https://github.com/moditect/moditect).
+
+The goal that adds a module descriptor to the project jar is
+[`add-module-info`](https://github.com/moditect/moditect#adding-a-module-descriptor-to-the-project-jar).
+
+With this plugin you can keep the `maven.compiler.release` property set to `8`, i.e. the same Java version for the whole build.
+
+A minimal example looks like this:
+
+```xml
+<project>
+  <properties>
+    <maven.compiler.release>8</maven.compiler.release>
+    <project.package.name>com.example.project</project.package.name>
+  </properties>
+
+  <build>
+    <plugin>
+      <groupId>org.moditect</groupId>
+      <artifactId>moditect-maven-plugin</artifactId>
+      <version>1.3.0.Final</version>
+      <executions>
+        <execution>
+          <id>add-module-infos</id>
+          <phase>package</phase>
+          <goals>
+            <goal>add-module-info</goal>
+          </goals>
+          <configuration>
+            <module>
+              <moduleInfo>
+                <name>${project.package.name}</name>
+                <exports>
+                  ${project.package.name};
+                </exports>
+              </moduleInfo>
+            </module>
+          </configuration>
+        </execution>
+      </executions>
+    </plugin>
+  </build>
+</project>
+```
+
+## Summary
+
+* `maven-compiler-plugin` + two compiler runs – flexible but a bit cumbersome.
+* `moditect-maven-plugin` – creates `module‑info.class` in a single build pass, keeps the target Java version (e.g., `8`) unchanged, and reduces build‑time complexity.


### PR DESCRIPTION
Adds the less complex moditect plugin to the module-info docs which is probably more helpful than compiling sources twice.

---


Following this checklist to help us incorporate your
contribution quickly and easily:

- [X] Your pull request should address just one issue, without pulling in other changes.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Each commit in the pull request should have a meaningful subject line and body. 
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. 
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
