### PR TITLE
Make mcompiler-120 IT locale independent

### DIFF
--- a/src/it/mcompiler-120/verify.groovy
+++ b/src/it/mcompiler-120/verify.groovy
@@ -20,7 +20,12 @@ def logFile = new File( basedir, 'build.log' )
 assert logFile.exists()
 content = logFile.text
 
+/*
+ * The message expected by this test was "unchecked call to add(E) as a member of the raw type List".
+ * But we cannot test that message because it is locale-dependent. Check only a few keywords instead.
+ */
+assert content.contains( 'add(E)' )
+assert content.contains( 'List' ) // May be `List` or `java.util.List`.
 assert content.contains( 'Compilation failure' )
 assert !content.contains( 'invalid flag' )
-assert content.contains( 'unchecked call to add(E) as a member of the raw type ' ) // List or java.util.List
 


### PR DESCRIPTION
Fix #1055 - Make IT mcompiler-120 locale-agnostic

**What:** Replace the locale-dependent verbatim assertion in `src/it/mcompiler-120/verify.groovy` with locale-independent keyword checks.

**Why:** The IT asserts `unchecked call to add(E) as a member of the raw type`, which is the English javac diagnostic. On non-English locales (e.g. German: "nicht geprüfter Aufruf von add(E) als Mitglied des Raw-Typs List") this assertion fails, making the IT pass only under English.

**How:** Replace the full English message check with two keyword assertions (`add(E)` and `List`) that appear in every locale because they are type/method tokens substituted into the localized template, not translated text. The existing `Compilation failure` and `invalid flag` guards are retained. This mirrors the approach already applied to the same IT on master.

No production code is changed. Only the IT verification script is touched.

Following this checklist to help us incorporate your
contribution quickly and easily:
- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
  *N/A. This is an IT-only fix with no runtime changes. The IT itself is the test.*
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure 
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
  *ICLA submitted to secretary@apache.org on June 22, 2026.*