### PR TITLE
fix: close Files.walk() stream in getOutputDirectoryPerVersion()

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
@@ -347,22 +347,24 @@ public class CompilerMojo extends AbstractCompilerMojo {
             return null;
         }
         final var paths = new TreeMap<SourceVersion, Path>();
-        Files.walk(root, 1).forEach((path) -> {
-            SourceVersion version;
-            if (path.equals(root)) {
-                path = outputDirectory;
-                version = SourceVersion.RELEASE_0;
-            } else {
-                try {
-                    version = SourceVersion.valueOf("RELEASE_" + path.getFileName());
-                } catch (IllegalArgumentException e) {
-                    throw new CompilationFailureException("Invalid version number for " + path, e);
+        try (Stream<Path> stream = Files.walk(root, 1)) {
+            stream.forEach((path) -> {
+                SourceVersion version;
+                if (path.equals(root)) {
+                    path = outputDirectory;
+                    version = SourceVersion.RELEASE_0;
+                } else {
+                    try {
+                        version = SourceVersion.valueOf("RELEASE_" + path.getFileName());
+                    } catch (IllegalArgumentException e) {
+                        throw new CompilationFailureException("Invalid version number for " + path, e);
+                    }
                 }
-            }
-            if (paths.put(version, path) != null) {
-                throw new CompilationFailureException("Duplicated version number for " + path);
-            }
-        });
+                if (paths.put(version, path) != null) {
+                    throw new CompilationFailureException("Duplicated version number for " + path);
+                }
+            });
+        }
         return paths;
     }
 


### PR DESCRIPTION
Fixes #1070

`Files.walk()` returns a `Stream<Path>` backed by a `DirectoryStream` handle. Without try-with-resources, the stream is only closed when garbage collected, which can cause "Too many open files" errors on multi-release projects with many versioned directories.

Wrapped the stream in a try-with-resources block to ensure prompt resource release.