### PR TITLE
Fix incremental detection of empty sources, 3.x

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -1559,8 +1559,25 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
             }
 
             try {
-                staleSources.addAll(scanner.getIncludedSources(rootFile, outputDirectory));
-            } catch (InclusionScanException e) {
+                Set<File> includedSources = scanner.getIncludedSources(rootFile, outputDirectory);
+                // The stale source scanner assumes that every source produces an output file. Filter its result only
+                // when the compiler provides an individual source-to-output mapping; aggregate outputs are ambiguous.
+                if (outputStyle == CompilerOutputStyle.ONE_OUTPUT_FILE_PER_INPUT_FILE) {
+                    for (File source : includedSources) {
+                        String relativePath =
+                                rootFile.toPath().relativize(source.toPath()).toString();
+                        boolean outputExists = mapping.getTargetFiles(outputDirectory, relativePath).stream()
+                                .anyMatch(File::exists);
+                        // A zero-byte compilation unit legitimately produces no class. Keep it stale if an output
+                        // exists, however, so that truncating an existing source is still detected as a change.
+                        if (Files.size(source.toPath()) != 0 || outputExists) {
+                            staleSources.add(source);
+                        }
+                    }
+                } else {
+                    staleSources.addAll(includedSources);
+                }
+            } catch (InclusionScanException | IOException e) {
                 throw new MojoExecutionException(
                         "Error scanning source root: \'" + sourceRoot + "\' for stale files to recompile.", e);
             }

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -1567,8 +1567,9 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
                         if (Files.size(source.toPath()) != 0) {
                             staleSources.add(source);
                         } else {
-                            String relativePath =
-                                    rootFile.toPath().relativize(source.toPath()).toString();
+                            String relativePath = rootFile.toPath()
+                                    .relativize(source.toPath())
+                                    .toString();
                             boolean outputExists = mapping.getTargetFiles(outputDirectory, relativePath).stream()
                                     .anyMatch(File::exists);
                             // A zero-byte compilation unit legitimately produces no class. Keep it stale if an output

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -1564,14 +1564,18 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
                 // when the compiler provides an individual source-to-output mapping; aggregate outputs are ambiguous.
                 if (outputStyle == CompilerOutputStyle.ONE_OUTPUT_FILE_PER_INPUT_FILE) {
                     for (File source : includedSources) {
-                        String relativePath =
-                                rootFile.toPath().relativize(source.toPath()).toString();
-                        boolean outputExists = mapping.getTargetFiles(outputDirectory, relativePath).stream()
-                                .anyMatch(File::exists);
-                        // A zero-byte compilation unit legitimately produces no class. Keep it stale if an output
-                        // exists, however, so that truncating an existing source is still detected as a change.
-                        if (Files.size(source.toPath()) != 0 || outputExists) {
+                        if (Files.size(source.toPath()) != 0) {
                             staleSources.add(source);
+                        } else {
+                            String relativePath =
+                                    rootFile.toPath().relativize(source.toPath()).toString();
+                            boolean outputExists = mapping.getTargetFiles(outputDirectory, relativePath).stream()
+                                    .anyMatch(File::exists);
+                            // A zero-byte compilation unit legitimately produces no class. Keep it stale if an output
+                            // exists, however, so that truncating an existing source is still detected as a change.
+                            if (outputExists) {
+                                staleSources.add(source);
+                            }
                         }
                     }
                 } else {

--- a/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.plugin.compiler;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -42,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -111,6 +113,27 @@ class CompilerMojoTest {
         Artifact projectArtifact = getVariableValueFromObject(compilerMojo, "projectArtifact");
         assertNull(
                 projectArtifact.getFile(), "MCOMPILER-94: artifact file should be null if there is nothing to compile");
+    }
+
+    /**
+     * Tests that an empty source file does not cause compilation every time because it has no class file.
+     */
+    @Test
+    @InjectMojo(goal = COMPILE, pom = "classpath:/unit/compiler-empty-source-change-detection-test/plugin-config.xml")
+    void testCompilerEmptySourceChangeDetection(CompilerMojo compilerMojo) throws Exception {
+        setUpCompilerMojoTestEnv(compilerMojo);
+
+        File source = new File(compilerMojo.getCompileSourceRoots().get(0), "Empty.java");
+        Files.createDirectories(source.getParentFile().toPath());
+        Files.write(source.toPath(), new byte[0]);
+
+        Log log = mock(Log.class);
+        compilerMojo.setLog(log);
+        compilerMojo.execute();
+
+        clearInvocations(log);
+        compilerMojo.execute();
+        verify(log).info("Nothing to compile - all classes are up to date.");
     }
 
     /**

--- a/src/test/resources/unit/compiler-empty-source-change-detection-test/plugin-config.xml
+++ b/src/test/resources/unit/compiler-empty-source-change-detection-test/plugin-config.xml
@@ -1,0 +1,37 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compileSourceRoots>
+            <compileSourceRoot>${basedir}/target/test-classes/unit/compiler-empty-source-change-detection-test/src/main/java</compileSourceRoot>
+          </compileSourceRoots>
+          <compilerId>javac</compilerId>
+          <release>17</release>
+          <outputDirectory>${basedir}/target/test/unit/compiler-empty-source-change-detection-test/target/classes</outputDirectory>
+          <buildDirectory>${basedir}/target/test/unit/compiler-empty-source-change-detection-test/target</buildDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/compiler-empty-source-change-detection-test/plugin-config.xml
+++ b/src/test/resources/unit/compiler-empty-source-change-detection-test/plugin-config.xml
@@ -27,7 +27,6 @@
             <compileSourceRoot>${basedir}/target/test-classes/unit/compiler-empty-source-change-detection-test/src/main/java</compileSourceRoot>
           </compileSourceRoots>
           <compilerId>javac</compilerId>
-          <release>17</release>
           <outputDirectory>${basedir}/target/test/unit/compiler-empty-source-change-detection-test/target/classes</outputDirectory>
           <buildDirectory>${basedir}/target/test/unit/compiler-empty-source-change-detection-test/target</buildDirectory>
         </configuration>


### PR DESCRIPTION
The stale source scanner assumes every Java source produces a mapped output, causing zero-byte compilation units to trigger recompilation on every invocation.

This change filters zero-byte stale candidates only for one-output-per-input compilers and only when no mapped output exists. This preserves detection when an existing source is truncated while leaving aggregate-output compilers unchanged.

A regression test compiles an empty source twice and verifies that the second invocation reports all classes as up to date.

Fixes #1000.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. 
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. 
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).