### PR TITLE
Fix incremental detection of empty sources, 4.x

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/IncrementalBuild.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/IncrementalBuild.java
@@ -773,15 +773,12 @@ final class IncrementalBuild {
 
     /**
      * {@return whether the given list of modified files should not cause a recompilation}
-     * This method returns {@code true} if the given list is empty or contains only files
-     * with the {@link SourceFile#ignoreModification} set to {@code true}, or empty source
-     * files for which no output file exists.
+     * This method returns {@code true} if the given list is empty or if
+     * {@link SourceFile#isEmptyOrIgnorable()} returns {@code true} for every file.
      *
      * @param sourceFiles return value of {@link #getModifiedSources()}.
      */
     static boolean isEmptyOrIgnorable(List<SourceFile> sourceFiles) {
-        return sourceFiles.stream()
-                .allMatch(
-                        (s) -> s.ignoreModification || (s.isEmpty && Files.notExists(s.getOutputFile(), LINK_OPTIONS)));
+        return sourceFiles.stream().allMatch(SourceFile::isEmptyOrIgnorable);
     }
 }

--- a/src/main/java/org/apache/maven/plugin/compiler/IncrementalBuild.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/IncrementalBuild.java
@@ -774,11 +774,14 @@ final class IncrementalBuild {
     /**
      * {@return whether the given list of modified files should not cause a recompilation}
      * This method returns {@code true} if the given list is empty or contains only files
-     * with the {@link SourceFile#ignoreModification} set to {@code true}.
+     * with the {@link SourceFile#ignoreModification} set to {@code true}, or empty source
+     * files for which no output file exists.
      *
      * @param sourceFiles return value of {@link #getModifiedSources()}.
      */
     static boolean isEmptyOrIgnorable(List<SourceFile> sourceFiles) {
-        return sourceFiles.stream().allMatch((s) -> s.ignoreModification);
+        return sourceFiles.stream()
+                .allMatch(
+                        (s) -> s.ignoreModification || (s.isEmpty && Files.notExists(s.getOutputFile(), LINK_OPTIONS)));
     }
 }

--- a/src/main/java/org/apache/maven/plugin/compiler/SourceFile.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/SourceFile.java
@@ -46,6 +46,11 @@ final class SourceFile {
     final long lastModified;
 
     /**
+     * Whether this source file is empty.
+     */
+    final boolean isEmpty;
+
+    /**
      * Whether this source has been flagged as new or modified since the last build.
      *
      * @see IncrementalBuildHelper#inputFileTreeChanges
@@ -84,6 +89,7 @@ final class SourceFile {
         this.directory = directory;
         this.file = file;
         this.lastModified = attrs.lastModifiedTime().toMillis();
+        this.isEmpty = attrs.size() == 0;
         this.ignoreModification = ignoreModification;
         directory.visit(file);
     }

--- a/src/main/java/org/apache/maven/plugin/compiler/SourceFile.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/SourceFile.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.plugin.compiler;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 
@@ -105,6 +106,15 @@ final class SourceFile {
         // The constants below must match the ones in `IncrementalBuild.SourceInfo`.
         return SourceDirectory.JAVA_FILE_SUFFIX.equals(directory.fileKind.extension)
                 && SourceDirectory.CLASS_FILE_SUFFIX.equals(directory.outputFileKind.extension);
+    }
+
+    /**
+     * {@return whether changes in this source file should not cause a recompilation}
+     * A source file is ignorable if its modification is explicitly ignored,
+     * or if the source file is empty and no corresponding output file exists.
+     */
+    boolean isEmptyOrIgnorable() {
+        return ignoreModification || (isEmpty && Files.notExists(getOutputFile()));
     }
 
     /**

--- a/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTestCase.java
+++ b/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTestCase.java
@@ -66,6 +66,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -181,6 +182,26 @@ public class CompilerMojoTestCase {
 
         testCompileMojo.execute();
         assertFalse(Files.exists(testCompileMojo.getOutputDirectory()));
+    }
+
+    /**
+     * Tests that an empty source file does not cause compilation every time because it has no class file.
+     */
+    @Test
+    @Basedir("${basedir}/target/test-classes/unit/compiler-empty-source-change-detection-test")
+    public void testCompilerEmptySourceChangeDetection(
+            @InjectMojo(goal = "compile", pom = "plugin-config.xml") CompilerMojo compileMojo) throws IOException {
+        Path source = compileMojo.basedir.resolve("src/main/java/Empty.java");
+        Files.createDirectories(source.getParent());
+        Files.write(source, new byte[0]);
+
+        Log log = mock(Log.class);
+        compileMojo.logger = log;
+        compileMojo.execute();
+
+        clearInvocations(log);
+        compileMojo.execute();
+        verify(log).info("Nothing to compile - all classes are up to date.");
     }
 
     /**

--- a/src/test/resources/unit/compiler-empty-source-change-detection-test/plugin-config.xml
+++ b/src/test/resources/unit/compiler-empty-source-change-detection-test/plugin-config.xml
@@ -1,0 +1,37 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project>
+  <build>
+    <directory>${project.basedir}/target</directory>
+    <outputDirectory>${project.basedir}/target/classes</outputDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compileSourceRoots>
+            <compileSourceRoot>${project.basedir}/src/main/java</compileSourceRoot>
+          </compileSourceRoots>
+          <release>17</release>
+          <incrementalCompilation>classes</incrementalCompilation>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Class-based incremental compilation assumes every Java source produces an inferred output file. A zero-byte compilation unit produces no class file, so it was detected as modified on every invocation.

This change records whether a source is empty using the file attributes already collected during source scanning. A modified zero-byte source is treated as ignorable only when its inferred output does not exist. If an output does exist, the source remains stale so truncating an existing source is still detected as a change.

A regression test compiles an empty source twice with class-based incremental detection and verifies that the second invocation reports all classes as up to date.

Fixes #1000.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. 
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. 
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).