### PR TITLE
Build fails when annotation processor list is empty (but present)

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -858,7 +858,11 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
 
         compilerConfiguration.setSourceLocations(compileSourceRoots);
 
-        compilerConfiguration.setAnnotationProcessors(annotationProcessors);
+        String[] processors = annotationProcessors;
+        if (processors != null && Arrays.stream(processors).allMatch(StringUtils::isBlank)) {
+            processors = null;
+        }
+        compilerConfiguration.setAnnotationProcessors(processors);
 
         compilerConfiguration.setProcessorPathEntries(resolveProcessorPathEntries());
 

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -858,11 +858,7 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
 
         compilerConfiguration.setSourceLocations(compileSourceRoots);
 
-        String[] processors = annotationProcessors;
-        if (processors != null && Arrays.stream(processors).allMatch(StringUtils::isBlank)) {
-            processors = null;
-        }
-        compilerConfiguration.setAnnotationProcessors(processors);
+        compilerConfiguration.setAnnotationProcessors(normalizeAnnotationProcessors(annotationProcessors));
 
         compilerConfiguration.setProcessorPathEntries(resolveProcessorPathEntries());
 
@@ -1607,6 +1603,21 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
             }
         }
         return newCompileSourceRootsList;
+    }
+
+    /**
+     * Removes blank annotation processor names.
+     *
+     * @param processors the configured annotation processor names, or {@code null}.
+     * @return the non-blank annotation processor names, or {@code null} if none remain.
+     */
+    static String[] normalizeAnnotationProcessors(String[] processors) {
+        if (processors != null) {
+            processors = Arrays.stream(processors)
+                    .filter(processor -> !StringUtils.isBlank(processor))
+                    .toArray(String[]::new);
+        }
+        return processors == null || processors.length == 0 ? null : processors;
     }
 
     /**

--- a/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTest.java
@@ -81,6 +81,17 @@ class CompilerMojoTest {
     }
 
     @Test
+    @InjectMojo(goal = COMPILE, pom = "classpath:/unit/compiler-empty-annotation-processors-test/plugin-config.xml")
+    void testCompilerEmptyAnnotationProcessors(CompilerMojo compilerMojo) throws Exception {
+        setUpCompilerMojoTestEnv(compilerMojo);
+
+        compilerMojo.execute();
+
+        File testClass = new File(compilerMojo.getOutputDirectory(), "TestCompile.class");
+        assertTrue(testClass::exists);
+    }
+
+    @Test
     @InjectMojo(goal = COMPILE, pom = "classpath:/unit/compiler-basic-sourcetarget/plugin-config.xml")
     void testCompilerBasicSourceTarget(CompilerMojo compilerMojo) throws Exception {
         setUpCompilerMojoTestEnv(compilerMojo);

--- a/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/compiler/CompilerMojoTest.java
@@ -35,6 +35,7 @@ import static org.apache.maven.api.plugin.testing.MojoExtension.getVariableValue
 import static org.apache.maven.api.plugin.testing.MojoExtension.setVariableValueToObject;
 import static org.apache.maven.plugin.compiler.MojoTestUtils.getMockMavenProject;
 import static org.apache.maven.plugin.compiler.MojoTestUtils.getMockMavenSession;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -89,6 +90,16 @@ class CompilerMojoTest {
 
         File testClass = new File(compilerMojo.getOutputDirectory(), "TestCompile.class");
         assertTrue(testClass::exists);
+    }
+
+    @Test
+    void testNormalizeAnnotationProcessors() {
+        assertNull(AbstractCompilerMojo.normalizeAnnotationProcessors(null));
+        assertNull(AbstractCompilerMojo.normalizeAnnotationProcessors(new String[] {"", " "}));
+        assertArrayEquals(
+                new String[] {"com.example.First", "com.example.Second"},
+                AbstractCompilerMojo.normalizeAnnotationProcessors(
+                        new String[] {"", "com.example.First", " ", "com.example.Second"}));
     }
 
     @Test

--- a/src/test/resources/unit/compiler-empty-annotation-processors-test/plugin-config.xml
+++ b/src/test/resources/unit/compiler-empty-annotation-processors-test/plugin-config.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compileSourceRoots>
+            <compileSourceRoot>${basedir}/target/test-classes/unit/compiler-empty-annotation-processors-test/src/main/java</compileSourceRoot>
+          </compileSourceRoots>
+          <annotationProcessors>
+          </annotationProcessors>
+          <compilerId>javac</compilerId>
+          <outputDirectory>${basedir}/target/test/unit/compiler-empty-annotation-processors-test/target/classes</outputDirectory>
+          <buildDirectory>${basedir}/target/test/unit/compiler-empty-annotation-processors-test/target</buildDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/compiler-empty-annotation-processors-test/src/main/java/TestCompile.java
+++ b/src/test/resources/unit/compiler-empty-annotation-processors-test/src/main/java/TestCompile.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+public class TestCompile {}


### PR DESCRIPTION
Fixes #892. [MCOMPILER-607] Build fails when annotation processor list is empty (but present)

When Maven maps an explicitly empty `<annotationProcessors>` configuration block, the resulting array contains a blank value rather than being empty or `null`. The 3.x compiler plugin passes that array to Plexus Compiler, which then invokes `javac` with `-processor ""`. Compilation fails because the empty processor name cannot be resolved.

This change treats an annotation processor array containing only blank values as unspecified before passing it to Plexus Compiler. Normal non-blank processor lists retain their existing behavior.

A regression test uses an actually empty XML `<annotationProcessors>` block and verifies that compilation succeeds. This covers the Maven configuration-mapping behavior that caused the bug.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MCOMPILER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MCOMPILER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MCOMPILER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
