### PR TITLE
[#1085] Document conservative incremental default on JDK < 23

### DIFF
--- a/src/it/incremental-proc-none-per-file/invoker.properties
+++ b/src/it/incremental-proc-none-per-file/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean compile
+invoker.goals.2 = org.codehaus.gmaven:groovy-maven-plugin:execute
+invoker.goals.3 = compile

--- a/src/it/incremental-proc-none-per-file/pom.xml
+++ b/src/it/incremental-proc-none-per-file/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.compiler.it</groupId>
+  <artifactId>incremental-proc-none-per-file</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>When annotation processing is disabled (proc=none), changing a single source file
+    must recompile only that file, not the whole source set, on every Java version. This is the
+    documented workaround for Java &lt; 23, where the default conservatively assumes an annotation
+    processor may be present (javac defaults to -proc:full) and rebuilds everything on any change.
+    This IT modifies one of three independent classes between two 'compile' invocations and asserts
+    that only one file is recompiled.</description>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>@project.version@</version>
+          <configuration>
+            <!-- proc=none disables annotation processing, so the default incremental configuration
+                 behaves per-file on every JDK, including Java < 23. See the incrementalCompilation
+                 "Default value" javadoc. -->
+            <proc>none</proc>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <!-- Called as second invoker goal to modify a single source file in place. -->
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <version>2.1.1</version>
+        <configuration>
+          <source>def f = new File( project.basedir, 'src/main/java/it/A.java' )
+            f.write( f.text.replaceAll( /return 1;/, 'return 999;' ) )</source>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.4.21</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/incremental-proc-none-per-file/src/main/java/it/A.java
+++ b/src/it/incremental-proc-none-per-file/src/main/java/it/A.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package it;
+
+public class A {
+    public int v() {
+        return 1;
+    }
+}

--- a/src/it/incremental-proc-none-per-file/src/main/java/it/B.java
+++ b/src/it/incremental-proc-none-per-file/src/main/java/it/B.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package it;
+
+public class B {
+    public int v() {
+        return 1;
+    }
+}

--- a/src/it/incremental-proc-none-per-file/src/main/java/it/C.java
+++ b/src/it/incremental-proc-none-per-file/src/main/java/it/C.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package it;
+
+public class C {
+    public int v() {
+        return 1;
+    }
+}

--- a/src/it/incremental-proc-none-per-file/verify.groovy
+++ b/src/it/incremental-proc-none-per-file/verify.groovy
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+def logFile = new File( basedir, 'build.log' )
+assert logFile.exists()
+def content = logFile.text
+
+// With proc=none (annotation processing disabled), changing exactly one of three independent
+// classes must recompile only the modified file, on every Java version. This is the documented
+// workaround for Java < 23, where the default otherwise conservatively rebuilds all files.
+assert content.contains( 'Compiling 1 modified source file' ) :
+        'Expected only the single modified source file to be recompiled'
+
+// It must NOT fall back to a full rebuild of the whole source set.
+assert !content.contains( 'Recompiling all files because at least one source file changed' ) :
+        'proc=none recompiled all files after a single-file change'

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -649,6 +649,16 @@ public abstract class AbstractCompilerMojo implements Mojo {
      * then the default value is same as above with the addition of {@code "rebuild-on-add,rebuild-on-change"}.
      * It means that a full rebuild will be done if any kind of change is detected.</p>
      *
+     * <p>Whether an annotation processor is considered present depends on the Java version when {@link #proc}
+     * is unset, because {@code javac} enables annotation processing by default before Java&nbsp;23
+     * ({@code -proc:full}) but disables it since Java&nbsp;23 ({@code -proc:none} unless a processor is
+     * configured). Consequently, on Java&nbsp;versions prior to&nbsp;23 the plugin conservatively assumes that
+     * a processor may be present — since {@code javac} would discover processors on the compile classpath —
+     * and therefore applies {@code "rebuild-on-add,rebuild-on-change"} by default, doing a full rebuild on any
+     * change even when no processor is actually present. Projects on Java&nbsp;&lt;&nbsp;23 that use no
+     * annotation processor can restore per-file recompilation by setting {@link #proc} to {@code "none"}
+     * (or by setting this {@code incrementalCompilation} property explicitly).</p>
+     *
      * @see #staleMillis
      * @see #fileExtensions
      * @see #showCompilationChanges

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -649,15 +649,15 @@ public abstract class AbstractCompilerMojo implements Mojo {
      * then the default value is same as above with the addition of {@code "rebuild-on-add,rebuild-on-change"}.
      * It means that a full rebuild will be done if any kind of change is detected.</p>
      *
-     * <p>Whether an annotation processor is considered present depends on the Java version when {@link #proc}
-     * is unset, because {@code javac} enables annotation processing by default before Java&nbsp;23
-     * ({@code -proc:full}) but disables it since Java&nbsp;23 ({@code -proc:none} unless a processor is
-     * configured). Consequently, on Java&nbsp;versions prior to&nbsp;23 the plugin conservatively assumes that
-     * a processor may be present — since {@code javac} would discover processors on the compile classpath —
-     * and therefore applies {@code "rebuild-on-add,rebuild-on-change"} by default, doing a full rebuild on any
-     * change even when no processor is actually present. Projects on Java&nbsp;&lt;&nbsp;23 that use no
-     * annotation processor can restore per-file recompilation by setting {@link #proc} to {@code "none"}
-     * (or by setting this {@code incrementalCompilation} property explicitly).</p>
+     * <p>Whether an annotation processor is considered present depends on the Java version when {@link #proc} is unset,
+     * because {@code javac} enables annotation processing by default before Java 23 ({@code -proc:full})
+     * but disables it since Java 23 ({@code -proc:none} unless a processor is configured).
+     * Consequently, on Java versions prior to 23 the plugin conservatively assumes that a processor may be present
+     * — since {@code javac} would discover processors on the compile classpath —
+     * and therefore applies {@code "rebuild-on-add,rebuild-on-change"} by default,
+     * doing a full rebuild on any change even when no processor is actually present.
+     * Projects on Java &lt; 23 that use no annotation processor can restore per-file recompilation
+     * by setting {@link #proc} to {@code "none"} (or by setting this {@code incrementalCompilation} property explicitly).</p>
      *
      * @see #staleMillis
      * @see #fileExtensions


### PR DESCRIPTION
Fixes #1085.

Per @desruisseaux's steer on the issue: the full rebuild on any change (when `proc` is unset on JDK < 23) is intentional. Before Java 23 `javac` defaults to `-proc:full` and discovers annotation processors on the compile classpath, and recompiling everything avoids losing processor-generated state (e.g. missed `META-INF/services` registrations). So this keeps the behaviour and documents it instead of changing it.

**Changes**

- `AbstractCompilerMojo`: clarify the `incrementalCompilation` default-value javadoc — why, on JDK < 23 with `proc` unset, the plugin conservatively assumes a processor may be present, and that setting `proc` to `none` (or an explicit `incrementalCompilation`) restores per-file recompilation.
- New IT `incremental-proc-none-per-file`: with `proc=none`, changing one of three independent classes recompiles only that file. This exercises the documented workaround and is green on all JDKs (verified on 21 and 25).

Doc + test only; no behavioural change.
