### PR TITLE
[MCOMPILER-595] Enable parameter metadata by default

### DIFF
--- a/src/it/MCOMPILER-298/invoker.properties
+++ b/src/it/MCOMPILER-298/invoker.properties
@@ -16,3 +16,4 @@
 # under the License.
 
 invoker.goals = test
+invoker.goals.2 = clean test -Dmaven.compiler.parameters=false -DexpectedParameterNamePresent=false

--- a/src/it/MCOMPILER-298/pom.xml
+++ b/src/it/MCOMPILER-298/pom.xml
@@ -45,9 +45,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>@project.version@</version>
-        <configuration>
-          <parameters>true</parameters>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/it/MCOMPILER-298/src/test/java/com/foo/ParameterTest.java
+++ b/src/it/MCOMPILER-298/src/test/java/com/foo/ParameterTest.java
@@ -26,11 +26,11 @@ public class ParameterTest {
 
     @Test
     public void testParameter() throws Exception {
-        assertEquals(
-                "parameterName",
-                ParameterClass.class
-                        .getMethod("method", String.class)
-                        .getParameters()[0]
-                        .getName());
+        var parameter = ParameterClass.class.getMethod("method", String.class).getParameters()[0];
+        boolean expectedNamePresent = Boolean.parseBoolean(System.getProperty("expectedParameterNamePresent", "true"));
+        assertEquals(expectedNamePresent, parameter.isNamePresent());
+        if (expectedNamePresent) {
+            assertEquals("parameterName", parameter.getName());
+        }
     }
 }

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -447,12 +447,13 @@ public abstract class AbstractCompilerMojo implements Mojo {
     /**
      * Whether to generate metadata for reflection on method parameters.
      * If {@code true}, the {@code -parameters} option will be added to compiler arguments.
+     * This is enabled by default. Set this parameter to {@code false} to omit the metadata.
      *
      * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html#option-parameters">javac -parameters</a>
      * @since 3.6.2
      */
-    @Parameter(property = "maven.compiler.parameters", defaultValue = "false")
-    protected boolean parameters;
+    @Parameter(property = "maven.compiler.parameters", defaultValue = "true")
+    protected boolean parameters = true;
 
     /**
      * Whether to include debugging information in the compiled class files.


### PR DESCRIPTION
## Summary

- Enable `-parameters` by default for both `compiler:compile` and `compiler:testCompile`.
- Document that `maven.compiler.parameters=false` opts out of parameter-name metadata.
- Extend the MCOMPILER-298 integration test to verify both the new default and the explicit opt-out.

## Motivation

More frameworks rely on reflection to obtain method parameter names. Generating that metadata by default makes those names available without requiring every project to opt in explicitly, while retaining a configuration switch for projects that do not want the metadata.

Fixes https://github.com/apache/maven-compiler-plugin/issues/858

## Validation

`JAVA_HOME=/opt/jdks/latest-21 /opt/maven/latest-4/bin/mvn -ntp -Prun-its -Dinvoker.test=MCOMPILER-298 clean verify`

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
