### PR TITLE
[MCOMPILER-569] Document implicitly compiled excluded sources

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
@@ -109,6 +109,10 @@ public class CompilerMojo extends AbstractCompilerMojo {
 
     /**
      * A list of exclusion filters for the compiler.
+     * A file such as {@code module-info.java} may still be compiled if it is implicitly referenced by the compiler,
+     * even if it has been excluded.
+     *
+     * @see AbstractCompilerMojo#implicit
      */
     @Parameter
     private Set<String> excludes = new HashSet<>();

--- a/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
@@ -109,8 +109,9 @@ public class CompilerMojo extends AbstractCompilerMojo {
 
     /**
      * A list of exclusion filters for the compiler.
-     * A file such as {@code module-info.java} may still be compiled if it is implicitly referenced by the compiler,
-     * even if it has been excluded.
+     * Excluding a source file only prevents the plugin from passing it explicitly to the compiler.
+     * The compiler may still find it on the source path and generate a class file for it.
+     * This can happen with {@code module-info.java}.
      *
      * @see AbstractCompilerMojo#implicit
      */

--- a/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
@@ -96,8 +96,9 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
 
     /**
      * A list of exclusion filters for the compiler.
-     * A file such as {@code module-info.java} may still be compiled if it is implicitly referenced by the compiler,
-     * even if it has been excluded.
+     * Excluding a source file only prevents the plugin from passing it explicitly to the compiler.
+     * The compiler may still find it on the source path and generate a class file for it.
+     * This can happen with {@code module-info.java}.
      *
      * @see AbstractCompilerMojo#implicit
      */

--- a/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
@@ -96,6 +96,10 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
 
     /**
      * A list of exclusion filters for the compiler.
+     * A file such as {@code module-info.java} may still be compiled if it is implicitly referenced by the compiler,
+     * even if it has been excluded.
+     *
+     * @see AbstractCompilerMojo#implicit
      */
     @Parameter
     private Set<String> testExcludes = new HashSet<>();


### PR DESCRIPTION
Clarify the `compile` and `testCompile` exclusion parameter documentation: an excluded source such as `module-info.java` may still be compiled when `javac` finds it implicitly. Link both parameters to `<implicit>`, which can be set to `none` to suppress class generation for implicitly referenced sources.

This documents the distinction between the plugin's explicit source filtering and `javac`'s implicit source discovery.

Fixes #778

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MCOMPILER) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue.  Your pull request should address just this issue, without
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MCOMPILER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MCOMPILER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
