### PR TITLE
[MCOMPILER-374] Unable to compile MR-JAR code against older directories when module-info.java is present

### DIFF
--- a/src/it/MCOMPILER-374_mrjar/invoker.properties
+++ b/src/it/MCOMPILER-374_mrjar/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.java.version = 11+

--- a/src/it/MCOMPILER-374_mrjar/pom.xml
+++ b/src/it/MCOMPILER-374_mrjar/pom.xml
@@ -34,6 +34,7 @@ under the License.
         <version>@project.version@</version>
         <configuration>
           <release>8</release>
+          <testRelease>11</testRelease>
         </configuration>
         <executions>
           <execution>

--- a/src/it/MCOMPILER-374_mrjar/pom.xml
+++ b/src/it/MCOMPILER-374_mrjar/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.maven.bug</groupId>
+  <artifactId>mcompiler374</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <release>8</release>
+        </configuration>
+        <executions>
+          <execution>
+            <id>java9</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>9</release>
+              <compileSourceRoots>
+                <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+              </compileSourceRoots>
+              <multiReleaseOutput>true</multiReleaseOutput>
+            </configuration>
+          </execution>
+          <execution>
+            <id>java11</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>11</release>
+              <compileSourceRoots>
+                <compileSourceRoot>${project.basedir}/src/main/java11</compileSourceRoot>
+              </compileSourceRoots>
+              <multiReleaseOutput>true</multiReleaseOutput>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/MCOMPILER-374_mrjar/src/main/java/org/maven/bug/A.java
+++ b/src/it/MCOMPILER-374_mrjar/src/main/java/org/maven/bug/A.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.maven.bug;
+
+public class A {
+    static int getCount() {
+        return 1;
+    }
+}

--- a/src/it/MCOMPILER-374_mrjar/src/main/java/org/maven/bug/B.java
+++ b/src/it/MCOMPILER-374_mrjar/src/main/java/org/maven/bug/B.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.maven.bug;
+
+public class B {
+    static int getCount() {
+        return A.getCount() + 1;
+    }
+}

--- a/src/it/MCOMPILER-374_mrjar/src/main/java11/module-info.java
+++ b/src/it/MCOMPILER-374_mrjar/src/main/java11/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module mrjar {
+    exports org.maven.bug;
+}

--- a/src/it/MCOMPILER-374_mrjar/src/main/java11/org/maven/bug/B.java
+++ b/src/it/MCOMPILER-374_mrjar/src/main/java11/org/maven/bug/B.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.maven.bug;
+
+public class B {
+    static int getCount() {
+        return A9.getCount() + 2;
+    }
+}

--- a/src/it/MCOMPILER-374_mrjar/src/main/java11/org/maven/bug/B.java
+++ b/src/it/MCOMPILER-374_mrjar/src/main/java11/org/maven/bug/B.java
@@ -22,4 +22,8 @@ public class B {
     static int getCount() {
         return A9.getCount() + 2;
     }
+
+    static int getVersion() {
+        return 11;
+    }
 }

--- a/src/it/MCOMPILER-374_mrjar/src/main/java9/org/maven/bug/A9.java
+++ b/src/it/MCOMPILER-374_mrjar/src/main/java9/org/maven/bug/A9.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.maven.bug;
+
+public class A9 {
+    static int getCount() {
+        return A.getCount() + 1;
+    }
+}

--- a/src/it/MCOMPILER-374_mrjar/src/main/java9/org/maven/bug/B.java
+++ b/src/it/MCOMPILER-374_mrjar/src/main/java9/org/maven/bug/B.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.maven.bug;
+
+public class B {
+    static int getCount() {
+        return A9.getCount() + 1;
+    }
+}

--- a/src/it/MCOMPILER-374_mrjar/src/test/java/org/maven/bug/MrJarTest.java
+++ b/src/it/MCOMPILER-374_mrjar/src/test/java/org/maven/bug/MrJarTest.java
@@ -16,11 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.maven.bug;
 
-assert new File(basedir, 'target/classes/org/maven/bug/A.class').exists()
-assert new File(basedir, 'target/classes/org/maven/bug/B.class').exists()
-assert new File(basedir, 'target/classes/META-INF/versions/9/org/maven/bug/A9.class').exists()
-assert new File(basedir, 'target/classes/META-INF/versions/9/org/maven/bug/B.class').exists()
-assert new File(basedir, 'target/classes/META-INF/versions/11/module-info.class').exists()
-assert new File(basedir, 'target/classes/META-INF/versions/11/org/maven/bug/B.class').exists()
-assert new File(basedir, 'target/test-classes/org/maven/bug/MrJarTest.class').exists()
+class MrJarTest {
+    static int getCount() {
+        return A.getCount() + A9.getCount() + B.getVersion();
+    }
+}

--- a/src/it/MCOMPILER-374_mrjar/verify.groovy
+++ b/src/it/MCOMPILER-374_mrjar/verify.groovy
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File(basedir, 'target/classes/org/maven/bug/A.class').exists()
+assert new File(basedir, 'target/classes/org/maven/bug/B.class').exists()
+assert new File(basedir, 'target/classes/META-INF/versions/9/org/maven/bug/A9.class').exists()
+assert new File(basedir, 'target/classes/META-INF/versions/9/org/maven/bug/B.class').exists()
+assert new File(basedir, 'target/classes/META-INF/versions/11/module-info.class').exists()
+assert new File(basedir, 'target/classes/META-INF/versions/11/org/maven/bug/B.class').exists()

--- a/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java
@@ -701,6 +701,32 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
         return Optional.empty();
     }
 
+    /**
+     * Returns existing multirelease JAR output directories through the given release in descending order.
+     * The base output directory is returned last.
+     */
+    protected static List<File> getProjectOutputDirectories(File outputDirectory, int release) {
+        List<File> directories = new ArrayList<>();
+        File versionsFolder = new File(outputDirectory, "META-INF/versions");
+
+        for (int version = release; version >= 9; version--) {
+            File versionSubFolder = new File(versionsFolder, String.valueOf(version));
+            if (versionSubFolder.isDirectory()) {
+                directories.add(versionSubFolder);
+            }
+        }
+
+        directories.add(outputDirectory);
+        return directories;
+    }
+
+    /**
+     * Returns the major Java version from its legacy or current string representation.
+     */
+    protected static int getJavaMajorVersion(String version) {
+        return Integer.parseInt(version.startsWith("1.") ? version.substring(2) : version);
+    }
+
     private boolean targetOrReleaseSet;
 
     @Override

--- a/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
@@ -32,6 +32,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.StringJoiner;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -257,6 +258,7 @@ public class CompilerMojo extends AbstractCompilerMojo {
         // assert compilePath != null;
 
         Optional<Path> moduleDeclaration = getModuleDeclaration(sourceFiles);
+        List<File> projectOutputDirectories = getProjectOutputDirectories(getProject());
 
         if (moduleDeclaration.isPresent()) {
             // For now only allow named modules. Once we can create a graph with ASM we can specify exactly the modules
@@ -269,7 +271,8 @@ public class CompilerMojo extends AbstractCompilerMojo {
 
             ResolvePathsResult<File> resolvePathsResult;
             try {
-                Collection<File> dependencyArtifacts = getCompileClasspathElements(getProject());
+                Collection<File> dependencyArtifacts =
+                        getCompileClasspathElements(getProject(), projectOutputDirectories);
 
                 ResolvePathsRequest<File> request = ResolvePathsRequest.ofFiles(dependencyArtifacts)
                         .setIncludeStatic(true)
@@ -307,13 +310,15 @@ public class CompilerMojo extends AbstractCompilerMojo {
 
                 for (File file : resolvePathsResult.getClasspathElements()) {
                     classpathElements.add(file.getPath());
+                }
 
-                    if (multiReleaseOutput) {
-                        if (getOutputDirectory().toPath().startsWith(file.getPath())) {
-                            compilerArgs.add("--patch-module");
-                            compilerArgs.add(String.format("%s=%s", moduleDescriptor.name(), file.getPath()));
-                        }
+                if (multiReleaseOutput) {
+                    StringJoiner patchPath = new StringJoiner(PS);
+                    for (File directory : projectOutputDirectories) {
+                        patchPath.add(directory.getPath());
                     }
+                    compilerArgs.add("--patch-module");
+                    compilerArgs.add(moduleDescriptor.name() + '=' + patchPath);
                 }
 
                 for (File file : resolvePathsResult.getModulepathElements().keySet()) {
@@ -329,7 +334,7 @@ public class CompilerMojo extends AbstractCompilerMojo {
             }
         } else {
             classpathElements = new ArrayList<>();
-            for (File element : getCompileClasspathElements(getProject())) {
+            for (File element : getCompileClasspathElements(getProject(), projectOutputDirectories)) {
                 classpathElements.add(element.getPath());
             }
             modulepathElements = Collections.emptyList();
@@ -362,23 +367,33 @@ public class CompilerMojo extends AbstractCompilerMojo {
         }
     }
 
-    private List<File> getCompileClasspathElements(MavenProject project) {
-        // 3 is outputFolder + 2 preserved for multirelease
-        List<File> list = new ArrayList<>(project.getArtifacts().size() + 3);
+    /**
+     * Returns the project output directories visible to the current compilation. For a multi-release output, existing
+     * earlier release directories are returned in descending order before the base output directory.
+     */
+    private List<File> getProjectOutputDirectories(MavenProject project) {
+        List<File> directories = new ArrayList<>();
+        File outputDirectory = new File(project.getBuild().getOutputDirectory());
 
         if (multiReleaseOutput) {
-            File versionsFolder = new File(project.getBuild().getOutputDirectory(), "META-INF/versions");
+            File versionsFolder = new File(outputDirectory, "META-INF/versions");
 
             // in reverse order
             for (int version = Integer.parseInt(getRelease()) - 1; version >= 9; version--) {
                 File versionSubFolder = new File(versionsFolder, String.valueOf(version));
                 if (versionSubFolder.exists()) {
-                    list.add(versionSubFolder);
+                    directories.add(versionSubFolder);
                 }
             }
         }
 
-        list.add(new File(project.getBuild().getOutputDirectory()));
+        directories.add(outputDirectory);
+        return directories;
+    }
+
+    private List<File> getCompileClasspathElements(MavenProject project, List<File> projectOutputDirectories) {
+        List<File> list = new ArrayList<>(project.getArtifacts().size() + projectOutputDirectories.size());
+        list.addAll(projectOutputDirectories);
 
         for (Artifact a : project.getArtifacts()) {
             if (a.getArtifactHandler().isAddedToClasspath()) {

--- a/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java
@@ -372,23 +372,13 @@ public class CompilerMojo extends AbstractCompilerMojo {
      * earlier release directories are returned in descending order before the base output directory.
      */
     private List<File> getProjectOutputDirectories(MavenProject project) {
-        List<File> directories = new ArrayList<>();
         File outputDirectory = new File(project.getBuild().getOutputDirectory());
 
         if (multiReleaseOutput) {
-            File versionsFolder = new File(outputDirectory, "META-INF/versions");
-
-            // in reverse order
-            for (int version = Integer.parseInt(getRelease()) - 1; version >= 9; version--) {
-                File versionSubFolder = new File(versionsFolder, String.valueOf(version));
-                if (versionSubFolder.exists()) {
-                    directories.add(versionSubFolder);
-                }
-            }
+            return getProjectOutputDirectories(outputDirectory, getJavaMajorVersion(getRelease()) - 1);
         }
 
-        directories.add(outputDirectory);
-        return directories;
+        return Collections.singletonList(outputDirectory);
     }
 
     private List<File> getCompileClasspathElements(MavenProject project, List<File> projectOutputDirectories) {

--- a/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java
@@ -21,6 +21,7 @@ package org.apache.maven.plugin.compiler;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.StringJoiner;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -235,11 +237,14 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
     protected void preparePaths(Set<File> sourceFiles) {
         File mainOutputDirectory = new File(getProject().getBuild().getOutputDirectory());
 
-        File mainModuleDescriptorClassFile = new File(mainOutputDirectory, "module-info.class");
+        List<File> mainOutputDirectories =
+                getProjectOutputDirectories(mainOutputDirectory, getEffectiveTestJavaVersion());
+        File mainModuleDescriptorClassFile = getModuleDescriptor(mainOutputDirectories);
         JavaModuleDescriptor mainModuleDescriptor = null;
 
         File testModuleDescriptorJavaFile = new File("module-info.java");
         JavaModuleDescriptor testModuleDescriptor = null;
+        List<String> effectiveTestPath = testPath;
 
         // Go through the source files to respect includes/excludes
         for (File sourceFile : sourceFiles) {
@@ -251,11 +256,14 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
         }
 
         // Get additional information from the main module descriptor, if available
-        if (mainModuleDescriptorClassFile.exists()) {
+        if (mainModuleDescriptorClassFile != null) {
             ResolvePathsResult<String> result;
 
             try {
-                ResolvePathsRequest<String> request = ResolvePathsRequest.ofStrings(testPath)
+                // LocationManager needs the directory containing the selected descriptor to recognize the main module.
+                effectiveTestPath = replacePathElement(
+                        testPath, mainOutputDirectory, mainModuleDescriptorClassFile.getParentFile());
+                ResolvePathsRequest<String> request = ResolvePathsRequest.ofStrings(effectiveTestPath)
                         .setIncludeStatic(true)
                         .setMainModuleDescriptor(mainModuleDescriptorClassFile.getAbsolutePath());
 
@@ -294,7 +302,7 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
             ResolvePathsResult<String> result;
 
             try {
-                ResolvePathsRequest<String> request = ResolvePathsRequest.ofStrings(testPath)
+                ResolvePathsRequest<String> request = ResolvePathsRequest.ofStrings(effectiveTestPath)
                         .setMainModuleDescriptor(testModuleDescriptorJavaFile.getAbsolutePath());
 
                 Toolchain toolchain = getToolchain();
@@ -331,7 +339,7 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
         }
 
         if (testModuleDescriptor != null) {
-            modulepathElements = testPath;
+            modulepathElements = effectiveTestPath;
             classpathElements = Collections.emptyList();
 
             if (mainModuleDescriptor != null) {
@@ -342,23 +350,22 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
                 }
 
                 if (testModuleDescriptor.name().equals(mainModuleDescriptor.name())) {
-                    if (compilerArgs == null) {
-                        compilerArgs = new ArrayList<>();
-                    }
-                    compilerArgs.add("--patch-module");
-
-                    StringBuilder patchModuleValue = new StringBuilder();
-                    patchModuleValue.append(testModuleDescriptor.name());
-                    patchModuleValue.append('=');
-
+                    List<String> mainSourceRoots = new ArrayList<>();
                     for (String root : getProject().getCompileSourceRoots()) {
                         if (Files.exists(Paths.get(root))) {
-                            patchModuleValue.append(root).append(PS);
+                            mainSourceRoots.add(root);
                         }
                     }
 
-                    compilerArgs.add(patchModuleValue.toString());
+                    // Tests in the main module need the layered MR-JAR output and the main sources as one patch.
+                    List<File> outputPatches =
+                            mainOutputDirectories.size() > 1 ? mainOutputDirectories : Collections.emptyList();
+                    addPatchModule(testModuleDescriptor.name(), outputPatches, mainSourceRoots);
                 } else {
+                    // Patch all output layers in multirelease lookup order so newer classes shadow older ones.
+                    if (mainOutputDirectories.size() > 1) {
+                        addPatchModule(mainModuleDescriptor.name(), mainOutputDirectories, Collections.emptyList());
+                    }
                     getLog().debug("Black-box testing - all is ready to compile");
                 }
             } else {
@@ -375,20 +382,8 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
             }
         } else {
             if (mainModuleDescriptor != null) {
-                if (compilerArgs == null) {
-                    compilerArgs = new ArrayList<>();
-                }
-                compilerArgs.add("--patch-module");
-
-                StringBuilder patchModuleValue = new StringBuilder(mainModuleDescriptor.name())
-                        .append('=')
-                        .append(mainOutputDirectory)
-                        .append(PS);
-                for (String root : compileSourceRoots) {
-                    patchModuleValue.append(root).append(PS);
-                }
-
-                compilerArgs.add(patchModuleValue.toString());
+                // Unnamed tests are compiled as a patch of the layered main module.
+                addPatchModule(mainModuleDescriptor.name(), mainOutputDirectories, compileSourceRoots);
 
                 compilerArgs.add("--add-reads");
                 compilerArgs.add(mainModuleDescriptor.name() + "=ALL-UNNAMED");
@@ -397,6 +392,57 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
                 classpathElements = testPath;
             }
         }
+    }
+
+    private int getEffectiveTestJavaVersion() {
+        String version = StringUtils.isNotEmpty(getRelease()) ? getRelease() : getTarget();
+        return getJavaMajorVersion(version);
+    }
+
+    static File getModuleDescriptor(List<File> outputDirectories) {
+        for (File outputDirectory : outputDirectories) {
+            File descriptor = new File(outputDirectory, "module-info.class");
+            if (descriptor.isFile()) {
+                return descriptor;
+            }
+        }
+        return null;
+    }
+
+    private static List<String> replacePathElement(List<String> path, File element, File replacement) {
+        List<String> result = new ArrayList<>(path.size());
+        Path elementPath = element.toPath().toAbsolutePath().normalize();
+        boolean replaced = false;
+
+        for (String value : path) {
+            if (Paths.get(value).toAbsolutePath().normalize().equals(elementPath)) {
+                result.add(replacement.getAbsolutePath());
+                replaced = true;
+            } else {
+                result.add(value);
+            }
+        }
+        if (!replaced) {
+            result.add(0, replacement.getAbsolutePath());
+        }
+        return result;
+    }
+
+    private void addPatchModule(String moduleName, List<File> outputDirectories, Collection<String> sourceRoots) {
+        if (compilerArgs == null) {
+            compilerArgs = new ArrayList<>();
+        }
+
+        StringJoiner patchPath = new StringJoiner(PS);
+        for (File dir : outputDirectories) {
+            patchPath.add(dir.getPath());
+        }
+        for (String sourceRoot : sourceRoots) {
+            patchPath.add(sourceRoot);
+        }
+
+        compilerArgs.add("--patch-module");
+        compilerArgs.add(moduleName + '=' + patchPath);
     }
 
     protected SourceInclusionScanner getSourceInclusionScanner(int staleMillis) {
@@ -438,11 +484,7 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
     }
 
     static boolean isOlderThanJDK9(String version) {
-        if (version.startsWith("1.")) {
-            return Integer.parseInt(version.substring(2)) < 9;
-        }
-
-        return Integer.parseInt(version) < 9;
+        return getJavaMajorVersion(version) < 9;
     }
 
     protected String getSource() {

--- a/src/test/java/org/apache/maven/plugin/compiler/TestCompilerMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/compiler/TestCompilerMojoTest.java
@@ -19,10 +19,12 @@
 package org.apache.maven.plugin.compiler;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -30,6 +32,7 @@ import org.apache.maven.api.plugin.testing.InjectMojo;
 import org.apache.maven.api.plugin.testing.MojoTest;
 import org.apache.maven.plugin.compiler.stubs.CompilerManagerStub;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -203,5 +206,27 @@ class TestCompilerMojoTest {
     @MethodSource
     void olderThanJDK9(String version, boolean expected) {
         assertEquals(expected, TestCompilerMojo.isOlderThanJDK9(version));
+    }
+
+    @Test
+    void shouldSelectApplicableModuleDescriptor(@TempDir Path temporaryDirectory) throws Exception {
+        Path outputDirectory = temporaryDirectory.resolve("classes");
+        Path version9 = Files.createDirectories(outputDirectory.resolve("META-INF/versions/9"));
+        Path version11 = Files.createDirectories(outputDirectory.resolve("META-INF/versions/11"));
+        Files.createDirectories(outputDirectory.resolve("META-INF/versions/17"));
+
+        Path version9Descriptor = Files.createFile(version9.resolve("module-info.class"));
+        Path version11Descriptor = Files.createFile(version11.resolve("module-info.class"));
+        Path rootDescriptor = Files.createFile(outputDirectory.resolve("module-info.class"));
+
+        List<File> outputDirectories = AbstractCompilerMojo.getProjectOutputDirectories(outputDirectory.toFile(), 11);
+        assertEquals(Arrays.asList(version11.toFile(), version9.toFile(), outputDirectory.toFile()), outputDirectories);
+        assertEquals(version11Descriptor.toFile(), TestCompilerMojo.getModuleDescriptor(outputDirectories));
+
+        Files.delete(version11Descriptor);
+        assertEquals(version9Descriptor.toFile(), TestCompilerMojo.getModuleDescriptor(outputDirectories));
+
+        Files.delete(version9Descriptor);
+        assertEquals(rootDescriptor.toFile(), TestCompilerMojo.getModuleDescriptor(outputDirectories));
     }
 }


### PR DESCRIPTION
## Summary

- Include existing output directories for earlier MR-JAR releases in the `--patch-module` path when the current compilation contains `module-info.java`.
- Reuse the same ordered output-directory list for the compiler class path and module patch path.
- Add an integration test covering release 8 base classes, a release 9 layer, and a modular release 11 layer that references a release 9 class.

## Motivation

The plugin already added earlier MR-JAR output directories to the class path. Once `module-info.java` is present, however, `javac` resolves the sources as a named module and the class path alone does not make those earlier classes part of that module.

The existing `--patch-module` option only contained the base output directory. The patch path now contains each existing earlier release directory in descending order, followed by the base output directory. This matches MR-JAR shadowing order and lets the modular execution see the output of earlier executions.

Fixes https://github.com/apache/maven-compiler-plugin/issues/579

## Testing

- `JAVA_HOME=/opt/jdks/latest-17 /opt/maven/latest/bin/mvn clean verify`
- `JAVA_HOME=/opt/jdks/latest-17 /opt/maven/latest/bin/mvn -Prun-its clean verify`
- `JAVA_HOME=/opt/jdks/latest-17 /opt/maven/latest/bin/mvn -Prun-its -Dinvoker.test=MCOMPILER-374_mrjar clean verify`
- `JAVA_HOME=/opt/jdks/latest-17 /opt/maven/latest/bin/mvn -Prun-its -Dinvoker.test=MCOMPILER-373_mrjar clean verify`

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MCOMPILER) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue.  Your pull request should address just this issue, without
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MCOMPILER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MCOMPILER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
