### PR TITLE
Fix documentation typos

### DIFF
--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -27,7 +27,7 @@ under the License.
     <faq id="how-to-add-generated-sources">
       <question>How do I add my generated sources to the compile path of Maven, when using Modello?</question>
       <answer>
-        <p>Modello generate the sources in the generate-sources phase and automatically adds the
+        <p>Modello generates the sources in the generate-sources phase and automatically adds the
           source directory for compilation in Maven. So you don't have to copy the generated sources.
         </p>
         <p>You have to declare the <a href="https://codehaus-plexus.github.io/modello/modello-maven-plugin/">Modello Maven Plugin</a>

--- a/src/site/markdown/examples/compile-using-different-jdk.md
+++ b/src/site/markdown/examples/compile-using-different-jdk.md
@@ -80,7 +80,7 @@ or sets an environment variable, so that the build remains portable.
     <profile>
       <id>compiler</id>
       <properties>
-        <JAVA_11_HOME>/usr/lib/jvm/java-11-openjdkk</JAVA_11_HOME>
+        <JAVA_11_HOME>/usr/lib/jvm/java-11-openjdk</JAVA_11_HOME>
       </properties>
     </profile>
   </profiles>

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -52,7 +52,7 @@ Of course, patches are welcome, too.
 Contributors can check out the project from our [source repository](./scm.html) and will find supplementary information
 in the [guide to helping with Maven](https://maven.apache.org/guides/development/guide-helping.html).
 
-The following pages describes how to use the plugin beyond the default
+The following pages describe how to use the plugin beyond the default
 "one source directory, one module, one release" default configuration:
 
 * [Declaration of source directories](./sources.html)
@@ -69,7 +69,7 @@ you can take a look into the following examples:
 * [Annotation processors](./examples/annotation-processor.html)
 * [Arguments related to Java Platform Module System](./examples/jpms_args.html)
 * [Compile using a different JDK](./examples/compile-using-different-jdk.html)
-* [Compile using a non-javac compilers](./examples/non-javac-compilers.html)
+* [Compile using a non-javac compiler](./examples/non-javac-compilers.html)
 * [Compile using the --source and --target javac options](./examples/set-compiler-source-and-target.html)
 * [Compile using the --release javac option](./examples/set-compiler-release.html)
 * [Compile using memory allocation enhancements](./examples/compile-with-memory-enhancements.html)

--- a/src/site/markdown/sources.md
+++ b/src/site/markdown/sources.md
@@ -46,7 +46,7 @@ One can write:
   <build>
     <sources>
       <source>
-        <scope>main</scope>     <!-- Can be omited as it is the default -->
+        <scope>main</scope>     <!-- Can be omitted as it is the default -->
         <directory>my-custom-dir/foo</directory>
       </source>
       <source>
@@ -54,7 +54,7 @@ One can write:
         <directory>my-custom-dir/bar</directory>
       </source>
     </sources>
-  <build>
+  </build>
 </project>
 ```
 
@@ -81,7 +81,7 @@ as their default values are `src/main/java` and `src/test/java` respectively.
         <!-- Default directory is src/main/java -->
       </source>
       <source>
-        <scope>main</scope>     <!-- Can be omited as it is the default -->
+        <scope>main</scope>     <!-- Can be omitted as it is the default -->
         <directory>src/extension/java</directory>
       </source>
       <source>
@@ -89,7 +89,7 @@ as their default values are `src/main/java` and `src/test/java` respectively.
         <!-- Default directory is src/test/java -->
       </source>
     </sources>
-  <build>
+  </build>
 </project>
 ```
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -44,7 +44,7 @@ under the License.
       <item name="Compile Using Memory Allocation Enhancements" href="examples/compile-with-memory-enhancements.html"/>
       <item name="Pass Compiler Arguments" href="examples/pass-compiler-arguments.html"/>
       <item name="Compile Using a Non-Javac Compiler" href="examples/non-javac-compilers.html"/>
-      <item name="Java 9+ Projects with module-info" href="examples/module-info.html"/>
+      <item name="Older projects with module-info" href="examples/module-info.html"/>
       <item name="Perform annotation processing" href="examples/annotation-processor.html"/>
     </menu>
   </body>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -43,8 +43,8 @@ under the License.
       <item name="Compile Using the --release javac Option" href="examples/set-compiler-release.html"/>
       <item name="Compile Using Memory Allocation Enhancements" href="examples/compile-with-memory-enhancements.html"/>
       <item name="Pass Compiler Arguments" href="examples/pass-compiler-arguments.html"/>
-      <item name="Non-javac compilerIds" href="examples/non-javac-compilers.html"/>
-      <item name="Older projects with module-info" href="examples/module-info.html"/>
+      <item name="Compile Using a Non-Javac Compiler" href="examples/non-javac-compilers.html"/>
+      <item name="Java 9+ Projects with module-info" href="examples/module-info.html"/>
       <item name="Perform annotation processing" href="examples/annotation-processor.html"/>
     </menu>
   </body>


### PR DESCRIPTION
## Changes

- index.md:53: Fixed 'describes' -> 'describe' (subject-verb agreement)
- index.md:61: Fixed 'non-javac compilers' -> 'non-javac compiler'
- sources.md:49,84: Fixed 'omited' -> 'omitted' (typo)
- sources.md:57,92: Added missing </build> closing tag in XML examples
- faq.fml:30: Fixed 'Modello generate' -> 'Modello generates' (grammar)
- compile-using-different-jdk.md:83: Fixed typo in path /java-11-openjdkk -> /java-11-openjdk
- site.xml:46: Renamed menu item 'Non-javac compilerIds' -> 'Compile Using a Non-Javac Compiler'
- site.xml:47: Renamed menu item 'Older projects with module-info' -> 'Java 9+ Projects with module-info'