### PR TITLE
Remove version numbers of plugins inherited from parent pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,12 +96,8 @@ under the License.
 
     <project.build.outputTimestamp>2026-01-27T00:46:35Z</project.build.outputTimestamp>
 
-    <!-- TODO remove with next parent -->
-    <maven4x.site.path>plugins-archives/${project.artifactId}-LATEST-4.x</maven4x.site.path>
-    <version.maven-compiler-plugin>3.14.1</version.maven-compiler-plugin>
-    <version.maven-dependency-plugin>3.9.0</version.maven-dependency-plugin>
-    <version.maven-invoker-plugin>3.9.1</version.maven-invoker-plugin>
     <!-- 4.x publish -->
+    <maven4x.site.path>plugins-archives/${project.artifactId}-LATEST-4.x</maven4x.site.path>
     <maven.site.path>${maven4x.site.path}</maven.site.path>
 
     <maven.compiler.source />


### PR DESCRIPTION
The plugins must be upgraded for compatibility with Java 26. But we do not need any more to declare those version numbers ourselves. It is now sufficient to inherit them from the parent `pom.xml`.

This pull request opportunistically changes the `invoker.toolchain.jdk.version` property of an integration test to match the `pom.xml`.