### PR TITLE
Fix tests on Jenkins

### DIFF
--- a/src/it/MCOMPILER-481-requires-static-included/invoker.properties
+++ b/src/it/MCOMPILER-481-requires-static-included/invoker.properties
@@ -15,5 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.goals = clean install 
-invoker.java.version = 11+
+invoker.goals = clean install
+# jetty 12.x required JDK 17+, use 21 as 17 failed on jenkins
+invoker.java.version = 21+


### PR DESCRIPTION
- jetty 12.x in MCOMPILER-481-requires-static-included required JDK 17+

test fail  on Jenkins with JDK 17, so use 21