### PR TITLE
Verify against Maven 4.0.0-rc-6

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -30,7 +30,7 @@ jobs:
       jdk-distribution-matrix: '[ "temurin", "zulu", "microsoft", "adopt-openj9" ]'
       jdk-matrix: '[ "8", "21", "25" ]'
       maven4-enabled: true
-      maven4-version: '4.0.0-rc-4'
+      maven4-version: '4.0.0-rc-6'
       verify-fail-fast: false
       matrix-exclude: '[
           { "jdk": "8", "distribution": "microsoft" },


### PR DESCRIPTION
Move the Maven 4 version used by the Verify workflow to 4.0.0-rc-6, the current RC. The 3.x line is unchanged otherwise — this only affects which Maven 4 the compatibility job runs.

Verified: green on the fork before opening.
