### PR TITLE
Keep the recompiling message at the INFO level when user explicitly requested that information

### DIFF
--- a/src/main/java/org/apache/maven/plugin/compiler/IncrementalBuild.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/IncrementalBuild.java
@@ -318,7 +318,7 @@ final class IncrementalBuild {
     /**
      * Whether to provide more details about why a module is rebuilt.
      */
-    private final boolean showCompilationChanges;
+    final boolean showCompilationChanges;
 
     /**
      * Creates a new helper for an incremental build.

--- a/src/main/java/org/apache/maven/plugin/compiler/ToolExecutor.java
+++ b/src/main/java/org/apache/maven/plugin/compiler/ToolExecutor.java
@@ -405,7 +405,12 @@ public class ToolExecutor {
                     if (n > 1) {
                         sb.append('s'); // Make plural.
                     }
-                    logger.info(sb.append('.'));
+                    sb.append('.');
+                    if (incrementalBuild.showCompilationChanges) {
+                        logger.info(sb);
+                    } else {
+                        logger.debug(sb);
+                    }
                 }
             }
             if (!(checkSources | checkDepends | checkOptions)) {


### PR DESCRIPTION
Keep the recompiling message at the INFO level when user explicitly requested that information. This pull request narrows the scope of #1089 to the case when the user did not requested that information.