### PR TITLE
Cleanup project with options exists in parent, bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,26 +85,23 @@ under the License.
     <mavenVersion>4.0.0-rc-6</mavenVersion>
 
     <asmVersion>9.10.1</asmVersion>
-    <guiceVersion>7.0.0</guiceVersion>
     <mockitoVersion>5.23.0</mockitoVersion>
     <eclipseCompilerVersion>3.42.0</eclipseCompilerVersion>
-    <version.maven-plugin-tools-3.x>3.13.1</version.maven-plugin-tools-3.x>
-    <version.maven-plugin-tools>4.0.0-beta-1</version.maven-plugin-tools>
+    <version.maven-plugin-tools-3.x>3.15.2</version.maven-plugin-tools-3.x>
+    <version.maven-plugin-tools>4.0.0-beta-2</version.maven-plugin-tools>
 
     <invoker.junitPackageName>org.apache.maven.plugins.compiler.its</invoker.junitPackageName>
-    <maven.it.failure.ignore>false</maven.it.failure.ignore>
 
     <project.build.outputTimestamp>2026-01-27T00:46:35Z</project.build.outputTimestamp>
 
     <!-- 4.x publish -->
-    <maven4x.site.path>plugins-archives/${project.artifactId}-LATEST-4.x</maven4x.site.path>
-    <maven.site.path>${maven4x.site.path}</maven.site.path>
+    <maven.site.path.suffix>LATEST-4.x</maven.site.path.suffix>
 
-    <maven.compiler.source />
-    <maven.compiler.target />
-    <maven.compiler.release>17</maven.compiler.release>
-    <minimalJavaBuildVersion>${maven.compiler.release}</minimalJavaBuildVersion>
+    <!-- The minimal Maven version that can build this plugin. The same as in prerequisites -->
+    <minimalMavenBuildVersion>${mavenVersion}</minimalMavenBuildVersion>
 
+    <!-- fail if dependencies are not declared or not used -->
+    <enforce.dependency.declarations>true</enforce.dependency.declarations>
   </properties>
 
   <dependencies>
@@ -152,12 +149,6 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-      <version>${guiceVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockitoVersion}</version>
@@ -173,13 +164,6 @@ under the License.
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <release>${javaVersion}</release>
-          </configuration>
-        </plugin>
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
@@ -206,33 +190,6 @@ under the License.
             </excludes>
           </configuration>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-pmd-plugin</artifactId>
-          <configuration>
-            <targetJdk>${maven.compiler.release}</targetJdk>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>enforce-bytecode-version</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <rules>
-                  <enforceBytecodeVersion>
-                    <maxJdkVersion>${maven.compiler.release}</maxJdkVersion>
-                  </enforceBytecodeVersion>
-                </rules>
-                <fail>true</fail>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
       </plugins>
     </pluginManagement>
   </build>
@@ -258,18 +215,12 @@ under the License.
                       <pomInclude>extras/*/pom.xml</pomInclude>
                       <pomInclude>multirelease-patterns/*/pom.xml</pomInclude>
                     </pomIncludes>
-                    <!--
-                      ! Unfortunately we can't define an execution order.
-                      ! https://issues.apache.org/jira/browse/MINVOKER-174
-                      -->
                     <setupIncludes>
                       <setupInclude>setup*/pom.xml</setupInclude>
                     </setupIncludes>
                     <postBuildHookScript>verify</postBuildHookScript>
                     <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
                     <settingsFile>src/it/settings.xml</settingsFile>
-                    <ignoreFailures>${maven.it.failure.ignore}</ignoreFailures>
-                    <streamLogsOnFailures>true</streamLogsOnFailures>
                     <goals>
                       <goal>clean</goal>
                       <goal>test-compile</goal>


### PR DESCRIPTION
- bump maven-plugin-tools 3.x and 4.x
- use only javaVersion, remove maven.compiler. properties
- remove plugin configuration - the same in parent
- remove unused guice dependency

